### PR TITLE
Fix stringifyCategory of GameSelection in backend

### DIFF
--- a/backend/src/game/elements/GameSelection.ts
+++ b/backend/src/game/elements/GameSelection.ts
@@ -82,7 +82,14 @@ export class    GameSelection {
     }
 
     static stringifyCategory(cat: Category): string {
-        const   s: string[] = ["Iron", "Bronze", "Silver", "Gold", "Platinum"];
+        const   s: string[] = [
+            "Pending",
+            "Iron",
+            "Bronze",
+            "Silver",
+            "Gold",
+            "Platinum"
+        ];
 
         return (s[cat]);
     }


### PR DESCRIPTION
Añadida la categoría "Pending" al método stringifyCategory del módulo GameSelection en el servidor.

Este error provocaba que se mostrara en el cliente del juego la categoría "Iron" para jugadores que tenían asignada la categoría "Pending".