### PR TITLE
Add game interpolation functionality

### DIFF
--- a/backend/src/game/elements/Game.ts
+++ b/backend/src/game/elements/Game.ts
@@ -25,6 +25,7 @@ export interface    IGameClientStart {
     playerB: IPlayerClientStart;
     ball: IBallClientStart;
     stage?: string;
+    when: number;
 }
 
 export interface    IInputData {
@@ -37,6 +38,7 @@ export interface    IGameData {
     playerA: IPlayerData;
     playerB: IPlayerData;
     ball: IBallData;
+    when: number;
 }
 
 export interface    IGameResult {
@@ -257,7 +259,8 @@ export class   Game {
         return ({
             playerA: this._playerA.data(),
             playerB: this._playerB.data(),
-            ball: this._ball.data()
+            ball: this._ball.data(),
+            when: this._lastUpdate
         });
     }
 
@@ -276,7 +279,8 @@ export class   Game {
             playerA: this._playerA.clientStartData(),
             playerB: this._playerB.clientStartData(),
             ball: this._ball.clientStartData(),
-            stage: this.stringifyStage(this._stage)
+            stage: this.stringifyStage(this._stage),
+            when: this._lastUpdate
         });
     }
 

--- a/backend/src/game/game.updateService.ts
+++ b/backend/src/game/game.updateService.ts
@@ -24,6 +24,8 @@ export class    GameUpdateService {
     gameSelections: Map<string, GameSelection>;
     updateInterval: NodeJS.Timer = undefined;
 
+    private readonly _UpdateIntervalTime: number = 1000 / 60;
+
     constructor(
         private readonly gameService: GameService,
         private readonly socketHelper: SocketHelper,
@@ -187,7 +189,7 @@ export class    GameUpdateService {
                         }
                     );
                 },
-                16
+                this._UpdateIntervalTime
             );
         }
         else if (this.updateInterval

--- a/frontend/src/app/game/elements/Ball.ts
+++ b/frontend/src/app/game/elements/Ball.ts
@@ -22,6 +22,8 @@ export class    Ball {
 
     private _ball: Phaser.GameObjects.Ellipse;
     private _ballShadow: Phaser.GameObjects.Ellipse;
+    private _xVel: number;
+    private _yVel: number;
 
     constructor(scene: MatchScene, initData: IBallInitData) {
         this._ball = scene.add.ellipse(
@@ -40,6 +42,8 @@ export class    Ball {
         );
         this._ball.depth = 1;
         this._ballShadow.depth = 0;
+        this._xVel = initData.xVel;
+        this._yVel = initData.yVel;
     }
 
     get xPos(): number {
@@ -50,11 +54,22 @@ export class    Ball {
         return (this._ball.y);
     }
 
+    get data(): IBallData {
+        return ({
+            xPos: this.xPos,
+            yPos: this.yPos,
+            xVel: this._xVel,
+            yVel: this._yVel
+        });
+    }
+
     update(data: IBallData): void {
         this._ball.x = data.xPos;
         this._ball.y = data.yPos;
         this._ballShadow.x = data.xPos;
         this._ballShadow.y = data.yPos;
+        this._xVel = data.xVel;
+        this._yVel = data.yVel;
     }
 
     destroy(): void {

--- a/frontend/src/app/game/elements/Hero.ts
+++ b/frontend/src/app/game/elements/Hero.ts
@@ -18,6 +18,8 @@ export interface    IHeroData {
     yPos: number;
     lowXPos: number;
     lowYPos: number;
+    activeSprite: number;
+    active: boolean; //Hero is active
 }
 
 export class    Hero {
@@ -37,6 +39,17 @@ export class    Hero {
         );
         this._upperSprite.setOrigin(initData.xOrigin, initData.yOrigin);
         this._lowerSprite.setOrigin(initData.lowXOrigin, initData.lowYOrigin);
+    }
+
+    get data(): IHeroData {
+        return ({
+            xPos: this._upperSprite.x,
+            yPos: this._upperSprite.y,
+            lowXPos: this._lowerSprite.x,
+            lowYPos: this._lowerSprite.y,
+            activeSprite: 0,
+            active: false
+        });
     }
 
     update(data: IHeroData): void {

--- a/frontend/src/app/game/elements/Match.ts
+++ b/frontend/src/app/game/elements/Match.ts
@@ -15,13 +15,15 @@ export interface    IMatchInitData {
     playerA: IPlayerInitData;
     playerB: IPlayerInitData;
     ball: IBallInitData;
-    stage: string;
+    stage?: string;
+    when: number;
 }
 
 export interface    IMatchData {
     playerA: IPlayerData;
     playerB: IPlayerData;
     ball: IBallData;
+    when: number;
 }
 
 export class    Match {
@@ -32,12 +34,13 @@ export class    Match {
     private _stage?: Phaser.GameObjects.Image;
     private _scoreTxt: Txt;
     private _scoreNicks: string;
+    private _when: number;
 
     constructor(scene: MatchScene, initData: IMatchInitData) {
         this._playerA = new Player(scene, initData.playerA);
         this._playerB = new Player(scene, initData.playerB);
         this._ball = new Ball(scene, initData.ball);
-        if (initData.playerA.hero)
+        if (initData.playerA.hero && initData.stage)
         {
             this._stage = scene.add.image(
                 Number(scene.game.config.width) / 2,
@@ -59,9 +62,40 @@ export class    Match {
             yOrigin: 0.5,
             depth: 0
         });
+        this._when = initData.when;
     }
 
-    update(data: IMatchData): void {
+    // Returns a Deep Copy of IPlayerData
+    private static _copyPlayer(data: IPlayerData): IPlayerData {
+        return ({
+            paddle: {...data.paddle},
+            hero: data.hero ? {...data.hero} : undefined,
+            score: data.score
+        });
+    }
+
+    // Returns a Deep Copy of IMatchData
+    static copyMatchData(data: IMatchData): IMatchData {
+        return ({
+            ball: {...data.ball},
+            playerA: this._copyPlayer(data.playerA),
+            playerB: this._copyPlayer(data.playerB),
+            when: data.when
+        });
+    }
+
+    get snapshot(): IMatchData {    
+        return ({
+            playerA: this._playerA.data,
+            playerB: this._playerB.data,
+            ball: this._ball.data,
+            when: this._when
+        });
+    }
+
+    update(data: IMatchData | undefined): void {
+        if (!data)
+            return ;
         if (data.playerA.score != this._playerA.score
                 || data.playerB.score != this._playerB.score)
         {
@@ -71,6 +105,7 @@ export class    Match {
         this._playerA.update(data.playerA);
         this._playerB.update(data.playerB);
         this._ball.update(data.ball);
+        this._when = data.when;
     }
 
     destroy(): void {

--- a/frontend/src/app/game/elements/Paddle.ts
+++ b/frontend/src/app/game/elements/Paddle.ts
@@ -46,6 +46,13 @@ export class    Paddle {
         return (this._paddle.y);
     }
 
+    get data(): IPaddleData {
+        return ({
+            xPos: this.xPos,
+            yPos: this.yPos
+        });
+    }
+
     update(data: IPaddleData): void {
         this._paddle.x = data.xPos;
         this._paddle.y = data.yPos;

--- a/frontend/src/app/game/elements/Player.ts
+++ b/frontend/src/app/game/elements/Player.ts
@@ -48,6 +48,14 @@ export class    Player {
         this._nick = initData.nick;
     }
 
+    get data(): IPlayerData {
+        return ({
+            paddle: this._paddle.data,
+            hero: this._hero ? this._hero.data : undefined,
+            score: this._score
+        });
+    }
+
     get score(): number {
         return (this._score);
     }

--- a/frontend/src/app/game/elements/SnapshotBuffer.ts
+++ b/frontend/src/app/game/elements/SnapshotBuffer.ts
@@ -1,0 +1,33 @@
+import {
+    IMatchData,
+    Match
+} from "./Match";
+import { LagCompensationService } from "../services/lag-compensation.service";
+
+export class   SnapshotBuffer {
+
+    private _buffer: IMatchData[];
+
+    constructor(
+        private readonly lagCompensator: LagCompensationService
+    ) {
+        this._buffer = [];
+    }
+
+    getSnapshot(): IMatchData | undefined {    
+        return (this._buffer.shift());
+    }
+
+    /*
+    **  Generates new snapshots based on the snapshot received
+    **  from the server.
+    */
+    update(serverSnapshot: IMatchData, currentSnapshot: IMatchData): void {
+        this.lagCompensator.serverUpdate(
+            this._buffer,
+            serverSnapshot,
+            currentSnapshot
+        );
+    }
+
+}

--- a/frontend/src/app/game/game.component.ts
+++ b/frontend/src/app/game/game.component.ts
@@ -8,6 +8,7 @@ import { MenuScene } from "./scenes/MenuScene";
 import { PlayerScene } from "./scenes/PlayerScene";
 import { SpectatorScene } from "./scenes/SpectatorScene";
 import { StartScene } from "./scenes/StartScene";
+import { LagCompensationService } from "./services/lag-compensation.service";
 
 @Component({
     selector: 'app-game',
@@ -22,7 +23,9 @@ export class    GameComponent implements OnInit {
     private queueButtonClick: boolean;
     private username?: string; //Provisional
 
-    constructor () {
+    constructor (
+        private readonly lagCompensator: LagCompensationService
+    ) {
         this.config = {
             type: Phaser.AUTO, //WEBGL if available. Canvas otherwise.
             parent: 'game_zone',
@@ -49,11 +52,14 @@ export class    GameComponent implements OnInit {
         const   menuHeroScene: MenuHeroScene =
                     new MenuHeroScene(this.socket, "Game1");
         const   playerScene: PlayerScene =
-                    new PlayerScene(this.socket, "Game1");
+                    new PlayerScene(this.socket, "Game1",
+                                        this.lagCompensator);
         const   classicPlayerScene: ClassicPlayerScene =
-                    new ClassicPlayerScene(this.socket, "Game1");
+                    new ClassicPlayerScene(this.socket, "Game1",
+                                        this.lagCompensator);
         const   spectatorScene: SpectatorScene =
-                    new SpectatorScene(this.socket, "Game1");
+                    new SpectatorScene(this.socket, "Game1",
+                                        this.lagCompensator);
         const   endScene: EndScene =
                     new EndScene(this.socket, "Game1");
             

--- a/frontend/src/app/game/scenes/ClassicPlayerScene.ts
+++ b/frontend/src/app/game/scenes/ClassicPlayerScene.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser'
 import * as SocketIO from 'socket.io-client'
+import { LagCompensationService } from '../services/lag-compensation.service';
 import { MatchScene } from './MatchScene';
 
 export class    ClassicPlayerScene extends MatchScene {
@@ -7,9 +8,10 @@ export class    ClassicPlayerScene extends MatchScene {
     cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
 
     constructor(
-        socket: SocketIO.Socket, room: string
+        socket: SocketIO.Socket, room: string,
+        override readonly lagCompensator: LagCompensationService
     ) {
-        super("ClassicPlayer", socket, room);
+        super("ClassicPlayer", socket, room, lagCompensator);
     }
 
     override create() {
@@ -18,11 +20,12 @@ export class    ClassicPlayerScene extends MatchScene {
         super.create();
     }
 
-    override update() {
+    override update() {    
         if (this.cursors?.up.isDown)
             this.socket.emit('paddleUp');
         else if (this.cursors?.down.isDown)
             this.socket.emit('paddleDown');
+        super.update();
     }
 
 }

--- a/frontend/src/app/game/scenes/PlayerScene.ts
+++ b/frontend/src/app/game/scenes/PlayerScene.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser'
 import * as SocketIO from 'socket.io-client'
+import { LagCompensationService } from '../services/lag-compensation.service';
 import { MatchScene } from './MatchScene';
 
 export class    PlayerScene extends MatchScene {
@@ -8,9 +9,10 @@ export class    PlayerScene extends MatchScene {
     powerKeys: any;
 
     constructor(
-        socket: SocketIO.Socket, room: string
+        socket: SocketIO.Socket, room: string,
+        override readonly lagCompensator: LagCompensationService
     ) {
-        super("Player", socket, room);
+        super("Player", socket, room, lagCompensator);
     }
 
     override create() {
@@ -32,6 +34,7 @@ export class    PlayerScene extends MatchScene {
             this.socket.emit('heroUp');
         else if (this.powerKeys.down.isDown)
             this.socket.emit('heroDown');
+        super.update();
     }
 
 }

--- a/frontend/src/app/game/scenes/SpectatorScene.ts
+++ b/frontend/src/app/game/scenes/SpectatorScene.ts
@@ -1,12 +1,14 @@
 import * as SocketIO from 'socket.io-client'
+import { LagCompensationService } from '../services/lag-compensation.service';
 import { MatchScene } from './MatchScene';
 
 export class    SpectatorScene extends MatchScene {
 
     constructor(
-        sock: SocketIO.Socket, room: string
+        sock: SocketIO.Socket, room: string,
+        override readonly lagCompensator: LagCompensationService
     ) {
-        super("Spectator", sock, room);
+        super("Spectator", sock, room, lagCompensator);
     }
 
 }

--- a/frontend/src/app/game/services/interpolation.service.spec.ts
+++ b/frontend/src/app/game/services/interpolation.service.spec.ts
@@ -1,0 +1,74 @@
+import { TestBed } from '@angular/core/testing';
+import { IBallData } from '../elements/Ball';
+import {
+    IMatchData,
+    Match
+} from '../elements/Match';
+import { IPaddleData } from '../elements/Paddle';
+import { IPlayerData } from '../elements/Player';
+
+import { InterpolationService } from './interpolation.service';
+
+const   sampleBall: IBallData = {
+    xPos: 400,
+    yPos: 300,
+    xVel: 300,
+    yVel: 300
+};
+
+const   samplePaddle: IPaddleData = {
+    xPos: 300,
+    yPos: 300
+};
+
+const   samplePlayer: IPlayerData = {
+    paddle: samplePaddle,
+    hero: undefined,
+    score: 0
+};
+
+const   sampleMatch: IMatchData = {
+    ball: sampleBall,
+    playerA: samplePlayer,
+    playerB: {
+        paddle: {...samplePlayer.paddle},
+        hero: samplePlayer.hero ? {...samplePlayer.hero} : undefined,
+        score: samplePlayer.score
+    },
+    when: 0
+};
+
+describe('InterpolationService', () => {
+    let service: InterpolationService;
+    let buffer: IMatchData[];
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({providers: [InterpolationService]});
+        service = TestBed.inject(InterpolationService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    it('should fill buffer with correct ball xPos interpolations', () => {
+        const   match: IMatchData = Match.copyMatchData(sampleMatch);
+        const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   totalSnapshots: number = 3;
+    
+        buffer = [];
+        buffer.length = 3;
+        buffer.fill({...match});
+        serverSnapshot.ball.xPos = 405;
+        serverSnapshot.ball.yPos = 305;
+        serverSnapshot.when = 1000 / 60;
+        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
+                            totalSnapshots);
+        expect(buffer.length).toBe(3);
+        expect(buffer[0].ball.xPos).toBe(405);
+        expect(buffer[1].ball.xPos).toBe(410);
+        expect(buffer[2].ball.xPos).toBe(415);
+    });
+
+});

--- a/frontend/src/app/game/services/interpolation.service.ts
+++ b/frontend/src/app/game/services/interpolation.service.ts
@@ -1,0 +1,188 @@
+import { Injectable } from "@angular/core";
+import { IHeroData } from "../elements/Hero";
+import {
+    IMatchData,
+    Match
+} from "../elements/Match";
+import { IPlayerData } from "../elements/Player";
+
+interface   IFixedTimeData {
+    base: number;
+    diff: number; // refSnapshot.when - base
+    target: number;
+}
+
+@Injectable ({
+    providedIn: 'root'
+})
+export class   InterpolationService {
+
+    /*
+    **  Convenience variable for each call. Indicates the number of snapshots
+    **  to generate and store in buffer.
+    */
+    private _totalSnapshots: number;
+
+    private readonly _serverUpdateInterval: number = 1000 / 60;
+
+    constructor() {
+        this._totalSnapshots = 0;
+    }
+
+    private _interpolate(refPos: number, basePos: number,
+                            timeData: IFixedTimeData): number {
+        const   diffPos = refPos - basePos;
+    
+        // Linear Interpolation formula
+        return (
+            basePos
+            + ((diffPos * (timeData.target - timeData.base)) / timeData.diff)
+        );
+    }
+
+    private _interpolateHero(refHero: IHeroData, baseHero: IHeroData,
+                                timeData: IFixedTimeData): void {
+        if (refHero.xPos != baseHero.xPos)
+        {
+            refHero.xPos = this._interpolate(
+                refHero.xPos,
+                baseHero.xPos,
+                timeData
+            );
+            refHero.yPos = this._interpolate(
+                refHero.yPos,
+                baseHero.yPos,
+                timeData
+            );
+        }
+        if (refHero.lowXPos != baseHero.lowXPos)
+        {
+            refHero.lowXPos = this._interpolate(
+                refHero.lowXPos,
+                baseHero.lowXPos,
+                timeData
+            );
+            refHero.lowYPos = this._interpolate(
+                refHero.lowYPos,
+                baseHero.lowYPos,
+                timeData
+            );
+        }
+    }
+
+    private _interpolatePlayer(refPlayer: IPlayerData,
+                                basePlayer: IPlayerData,
+                                timeData: IFixedTimeData): void {
+        refPlayer.paddle.yPos = this._interpolate(
+            refPlayer.paddle.yPos,
+            basePlayer.paddle.yPos,
+            timeData
+        );
+        if (refPlayer.hero
+            && basePlayer.hero)
+        {
+            this._interpolateHero(
+                refPlayer.hero,
+                basePlayer.hero,
+                timeData
+            );
+        }
+    }
+
+    private _interpolateBall(snapshot: IMatchData,
+                                baseSnapshot: IMatchData,
+                                timeData: IFixedTimeData): void {
+        if (snapshot.ball.xVel === 0)
+            return ;
+        snapshot.ball.xPos = this._interpolate(
+            snapshot.ball.xPos,
+            baseSnapshot.ball.xPos,
+            timeData
+        );
+        snapshot.ball.yPos = this._interpolate(
+            snapshot.ball.yPos,
+            baseSnapshot.ball.yPos,
+            timeData
+        );
+    }
+
+    private _getFixedTimeData(refTime: number, baseTime: number,
+                                currentStep: number): IFixedTimeData {
+        const   targetTime = baseTime + ((1000 / 60) * currentStep);
+        
+        return ({
+            base: baseTime,
+            diff: refTime - baseTime,
+            target: targetTime
+        });
+    }
+
+    private _generateSnapshot(refSnapshot: IMatchData,
+                                baseSnapshot: IMatchData,
+                                currentStep: number): IMatchData {
+        const   timeData: IFixedTimeData = this._getFixedTimeData(
+            refSnapshot.when,
+            baseSnapshot.when,
+            currentStep
+        );
+        const   snapshot: IMatchData = Match.copyMatchData(refSnapshot);
+
+        this._interpolateBall(snapshot, baseSnapshot, timeData);
+        this._interpolatePlayer(
+            snapshot.playerA,
+            baseSnapshot.playerA,
+            timeData
+        );
+        this._interpolatePlayer(
+            snapshot.playerB,
+            baseSnapshot.playerB,
+            timeData
+        );
+        if (snapshot.ball.xVel != 0)
+            snapshot.when = timeData.target;
+        return (snapshot);
+    }
+
+    private _fillLoop(buffer: IMatchData[], serverSnapshot: IMatchData,
+                        currentSnapshot: IMatchData): void {
+        let currentStep: number;
+        let generatedSnapshot: IMatchData;
+
+        for (let i = 0; i < this._totalSnapshots; ++i)
+        {
+            currentStep = i + 1;
+            generatedSnapshot = this._generateSnapshot(
+                serverSnapshot,
+                currentSnapshot,
+                currentStep
+            );
+            if (i < buffer.length)
+                buffer[i] = Match.copyMatchData(generatedSnapshot);
+            else
+                buffer.push(Match.copyMatchData(generatedSnapshot));
+        }
+    }
+
+    private _stopTime(buffer: IMatchData[], serverSnapshot: IMatchData): void {
+        buffer.length = 0;
+        buffer.push(Match.copyMatchData(serverSnapshot));
+    }
+
+    fillBuffer(buffer: IMatchData[], serverSnapshot: IMatchData,
+                currentSnapshot: IMatchData, totalSnapshots: number): void {
+        const   timeOffset: number = serverSnapshot.when - currentSnapshot.when;
+    
+        this._totalSnapshots = totalSnapshots;
+        if (timeOffset < this._serverUpdateInterval)
+            this._stopTime(buffer, serverSnapshot);
+        else
+        {
+            this._fillLoop(buffer, serverSnapshot,
+                            buffer[0] ? Match.copyMatchData(buffer[0])
+                            : currentSnapshot); //Provisional
+        }
+        while (buffer.length > this._totalSnapshots)
+            buffer.pop();
+    }
+
+}

--- a/frontend/src/app/game/services/lag-compensation.service.ts
+++ b/frontend/src/app/game/services/lag-compensation.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@angular/core";
+import { IMatchData } from "../elements/Match";
+import { InterpolationService } from "./interpolation.service";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class    LagCompensationService {
+
+    private readonly _bufferSnapshots: number = 1;
+
+    constructor(
+        private readonly interpolService: InterpolationService
+    ) {}
+
+    serverUpdate(buffer: IMatchData[], serverSnapshot: IMatchData,
+                    currentSnapshot: IMatchData): void {
+        this.interpolService.fillBuffer(
+            buffer,
+            serverSnapshot,
+            currentSnapshot,
+            this._bufferSnapshots
+        );
+    }
+
+}


### PR DESCRIPTION
Añadido servicio de interpolación para el juego en el cliente. Además de este servicio, se ha añadido un buffer de snapshots para cada partida. Un snapshot contiene los datos del juego en un momento determinado.

Esto permite que se puedan generar snapshots en el cliente a partir de un snapshot recibido del servidor y almacenarlos en el buffer. De esta manera, se podrá mostrar al jugador actualizaciones del estado del juego, fidedignas, pero que ya han ocurrido, de forma regular, sin depender del momento en el que se reciba la información del servidor.

La capacidad del buffer se ha reducido a un elemento porque se necesita combinar el servicio de interpolación con uno de extrapolación para conseguir generar snapshots precisas.