### PR TITLE
Add extrapolation and prediction services for ball

### DIFF
--- a/backend/src/game/game.updateService.ts
+++ b/backend/src/game/game.updateService.ts
@@ -24,7 +24,7 @@ export class    GameUpdateService {
     gameSelections: Map<string, GameSelection>;
     updateInterval: NodeJS.Timer = undefined;
 
-    private readonly _UpdateIntervalTime: number = 1000 / 60;
+    private readonly _UpdateIntervalTime: number = 1000 / 20;
 
     constructor(
         private readonly gameService: GameService,

--- a/frontend/src/app/game/elements/SnapshotBuffer.ts
+++ b/frontend/src/app/game/elements/SnapshotBuffer.ts
@@ -1,6 +1,6 @@
 import {
     IMatchData,
-    Match
+    IMatchInitData
 } from "./Match";
 import { LagCompensationService } from "../services/lag-compensation.service";
 
@@ -9,13 +9,33 @@ export class   SnapshotBuffer {
     private _buffer: IMatchData[];
 
     constructor(
+        gameWidth: number,
+        gameHeight: number,
+        initData: IMatchInitData,
         private readonly lagCompensator: LagCompensationService
     ) {
         this._buffer = [];
+        this.lagCompensator.init({
+            gameWidth: gameWidth,
+            gameHeight: gameHeight,
+            paddleWidth: initData.playerA.paddle.width,
+            paddleHeight: initData.playerA.paddle.height,
+            aPaddleX: initData.playerA.paddle.xPos,
+            bPaddleX: initData.playerB.paddle.xPos,
+            ballRadius: initData.ball.width / 2,
+        });
     }
 
-    getSnapshot(): IMatchData | undefined {    
+    get size(): number {
+        return (this._buffer.length);
+    }
+
+    getSnapshot(): IMatchData | undefined {
         return (this._buffer.shift());
+    }
+
+    autofill(): void {
+        this.lagCompensator.autoFill(this._buffer);
     }
 
     /*

--- a/frontend/src/app/game/scenes/MatchScene.ts
+++ b/frontend/src/app/game/scenes/MatchScene.ts
@@ -78,7 +78,12 @@ export class    MatchScene extends BaseScene {
         if (this.initData != undefined)
         {
             this.match = new Match(this, this.initData);
-            this.buffer = new SnapshotBuffer(this.lagCompensator);
+            this.buffer = new SnapshotBuffer(
+                Number(this.game.config.width),
+                Number(this.game.config.height),
+                this.initData,
+                this.lagCompensator
+            );
         }
         this.createInitText();
         this.initData = undefined;
@@ -88,6 +93,8 @@ export class    MatchScene extends BaseScene {
         this.match?.update(
             this.buffer?.getSnapshot()
         );
+        if (this.buffer?.size === 1)
+            this.buffer.autofill();
     }
 
 }

--- a/frontend/src/app/game/services/extrapolation.service.spec.ts
+++ b/frontend/src/app/game/services/extrapolation.service.spec.ts
@@ -1,0 +1,79 @@
+import { TestBed } from '@angular/core/testing';
+import { IBallData } from '../elements/Ball';
+import {
+    IMatchData,
+    Match
+} from '../elements/Match';
+import { IPlayerData } from '../elements/Player';
+import { ExtrapolationService } from './extrapolation.service';
+import { IPredictionInit } from './prediction.service';
+
+const   sampleBall: IBallData = {
+    xPos: 400,
+    yPos: 300,
+    xVel: 300,
+    yVel: 300
+};
+
+const   samplePlayer: IPlayerData = {
+    paddleY: 300,
+    hero: undefined,
+    score: 0
+};
+
+const   sampleMatch: IMatchData = {
+    ball: sampleBall,
+    playerA: samplePlayer,
+    playerB: {
+        paddleY: samplePlayer.paddleY,
+        hero: samplePlayer.hero ? {...samplePlayer.hero} : undefined,
+        score: samplePlayer.score
+    },
+    when: 0
+};
+
+const   samplePredictionInit: IPredictionInit = {
+    gameWidth: 800,
+    gameHeight: 600,
+    ballRadius: 5,
+    aPaddleX: 800 * 0.9,
+    bPaddleX: 800 * 0.1,
+    paddleHeight: 50,
+    paddleWidth: 10
+};
+
+describe('ExtrapolationService', () => {
+    let service: ExtrapolationService;
+    let buffer: IMatchData[];
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({providers: [ExtrapolationService]});
+        service = TestBed.inject(ExtrapolationService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    it('should fill buffer with correct extrapolations', () => {
+        const   bufferSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   totalSnapshots: number = 3;
+        const   interval: number = 1000 / 60;
+    
+        buffer = [];
+        bufferSnapshot.ball.xPos = 405;
+        bufferSnapshot.ball.yPos = 305;
+        bufferSnapshot.when = interval;
+        buffer.push(bufferSnapshot);
+        service.init(samplePredictionInit);
+        service.fillBuffer(buffer, totalSnapshots);
+        expect(buffer.length).toBe(3);
+        expect(buffer[0].ball.xPos).toBe(405);
+        expect(buffer[0].when).toBe(interval);
+        expect(buffer[1].ball.xPos).toBe(410);
+        expect(buffer[1].when).toBe(interval * 2);
+        expect(buffer[2].ball.xPos).toBe(415);
+        expect(buffer[2].when).toBe(interval * 3);
+    });
+
+});

--- a/frontend/src/app/game/services/extrapolation.service.ts
+++ b/frontend/src/app/game/services/extrapolation.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from "@angular/core";
+import {
+    IMatchData,
+    Match
+} from "../elements/Match";
+import {
+    IPredictionInit,
+    IPredictionInput,
+    IPredictionOutput,
+    PredictionService
+} from "./prediction.service";
+
+@Injectable({
+    providedIn: 'root'
+})
+export class    ExtrapolationService {
+
+    /*
+    **  Convenience variable for each call. Indicates the number of snapshots
+    **  to generate and store in buffer.
+    */
+    private _totalSnapshots: number;
+
+    private readonly _snapshotInterval: number = 1000 / 60;
+
+    constructor(
+        private readonly predictor: PredictionService
+    ) {
+        this._totalSnapshots = 0;
+    }
+
+    init(data: IPredictionInit): void {
+        this.predictor.init(data);
+    }
+
+    private _extrapolate(
+        data: IPredictionInput
+    ): IPredictionOutput | undefined {
+        return (
+            this.predictor.getSnapshot(data)
+        );
+    }
+
+    private _getSnapshot(refSnapshot: IMatchData,
+                            targetTime: number): IMatchData {
+        const   genSnapshot: IMatchData = Match.copyMatchData(refSnapshot);
+        const   prediction: IPredictionOutput | undefined = this._extrapolate({
+            fromTime: refSnapshot.when,
+            toTime: targetTime,
+            aPaddleY: refSnapshot.playerA.paddleY,
+            bPaddleY: refSnapshot.playerB.paddleY,
+            ball: refSnapshot.ball
+        });
+
+        if (!prediction)
+            return (genSnapshot);
+        genSnapshot.ball = prediction.ball;
+        genSnapshot.when = targetTime;
+        return (genSnapshot);
+    }
+
+    /*
+    **  Called when the buffer has only one snapshot left and there is no data
+    **  available from the server to generate interpolated or extrapolated
+    **  snapshots with.
+    */
+    fillBuffer(buffer: IMatchData[], totalSnapshots: number): void {
+        let     generatedSnapshot: IMatchData;
+        let     refSnapshot: IMatchData;
+
+        if (!buffer.length)
+            return ;
+        this._totalSnapshots = totalSnapshots;
+        for (let i = 1; i < this._totalSnapshots; ++i)
+        {
+            refSnapshot = buffer[i - 1];
+            generatedSnapshot = this._getSnapshot(
+                refSnapshot,
+                refSnapshot.when + this._snapshotInterval
+            );
+            buffer.push(generatedSnapshot);
+        }
+    }
+
+}

--- a/frontend/src/app/game/services/interpolation.service.spec.ts
+++ b/frontend/src/app/game/services/interpolation.service.spec.ts
@@ -46,23 +46,81 @@ describe('InterpolationService', () => {
     });
 
     it('should fill buffer with correct ball xPos interpolations', () => {
-        const   match: IMatchData = Match.copyMatchData(sampleMatch);
         const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   totalSnapshots: number = 3;
     
         buffer = [];
-        buffer.length = 3;
-        buffer.fill({...match});
-        serverSnapshot.ball.xPos = 405;
-        serverSnapshot.ball.yPos = 305;
-        serverSnapshot.when = 1000 / 60;
+        serverSnapshot.ball.xPos = 415;
+        serverSnapshot.ball.yPos = 315;
+        serverSnapshot.when = 1000 / 20;
         service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
                             totalSnapshots);
         expect(buffer.length).toBe(3);
         expect(buffer[0].ball.xPos).toBe(405);
         expect(buffer[1].ball.xPos).toBe(410);
         expect(buffer[2].ball.xPos).toBe(415);
+    });
+
+    it('should update 1 buffer snapshot and add other 2', () => {
+        const   bufferSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   totalSnapshots: number = 3;
+        const   interval: number = 1000 / 60;
+    
+        buffer = [];
+        bufferSnapshot.ball.xPos = 405;
+        bufferSnapshot.ball.yPos = 305;
+        bufferSnapshot.when = currentSnapshot.when + interval;
+        buffer.push(bufferSnapshot);
+        serverSnapshot.ball.xPos = 415;
+        serverSnapshot.ball.yPos = 315;
+        serverSnapshot.playerA.paddleY = 500;
+        serverSnapshot.when = interval * 3;
+        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
+                            totalSnapshots);
+        expect(buffer.length).toBe(3);
+        expect(buffer[0].ball.xPos).toBe(405);
+        expect(buffer[0].playerA.paddleY).toBeGreaterThan(
+            sampleMatch.playerA.paddleY
+        );
+        expect(buffer[0].when).toBe(currentSnapshot.when + interval);
+        expect(buffer[1].ball.xPos).toBe(410);
+        expect(buffer[1].playerA.paddleY).toBeGreaterThan(
+            buffer[0].playerA.paddleY
+        );
+        expect(buffer[1].when).toBe(buffer[0].when + interval);
+        expect(buffer[2].ball.xPos).toBe(415);
+        expect(buffer[2].playerA.paddleY).toBe(serverSnapshot.playerA.paddleY);
+        expect(buffer[2].when).toBe(buffer[1].when + interval);
+    });
+
+    it('should substitute 1 buffer snapshot and add other 2', () => {
+        const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
+        const   totalSnapshots: number = 3;
+        const   interval: number = 1000 / 60;
+        let     bufferSnapshot: IMatchData;
+    
+        currentSnapshot.ball.xVel = 0;
+        currentSnapshot.ball.yVel = 0;
+        buffer = [];
+        bufferSnapshot = Match.copyMatchData(currentSnapshot);
+        bufferSnapshot.when = currentSnapshot.when + interval;
+        buffer.push(bufferSnapshot);
+        serverSnapshot.ball.xPos = 415;
+        serverSnapshot.ball.yPos = 315;
+        serverSnapshot.when = interval * 3;
+        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
+                            totalSnapshots);
+        expect(buffer.length).toBe(3);
+        expect(buffer[0].ball.xPos).toBe(405);
+        expect(buffer[0].when).toBe(currentSnapshot.when + interval);
+        expect(buffer[1].ball.xPos).toBe(410);
+        expect(buffer[1].when).toBe(buffer[0].when + interval);
+        expect(buffer[2].ball.xPos).toBe(415);
+        expect(buffer[2].when).toBe(buffer[1].when + interval);
     });
 
 });

--- a/frontend/src/app/game/services/lag-compensation.service.ts
+++ b/frontend/src/app/game/services/lag-compensation.service.ts
@@ -1,17 +1,28 @@
 import { Injectable } from "@angular/core";
 import { IMatchData } from "../elements/Match";
+import { ExtrapolationService } from "./extrapolation.service";
 import { InterpolationService } from "./interpolation.service";
+import { IPredictionInit } from "./prediction.service";
 
 @Injectable({
     providedIn: 'root'
 })
 export class    LagCompensationService {
 
-    private readonly _bufferSnapshots: number = 1;
+    private readonly _bufferSnapshots: number = 3;
 
     constructor(
-        private readonly interpolService: InterpolationService
+        private readonly interpolService: InterpolationService,
+        private readonly extrapolService: ExtrapolationService
     ) {}
+
+    init(initData: IPredictionInit): void {
+        this.extrapolService.init(initData);
+    }
+
+    autoFill(buffer: IMatchData[]): void {
+        this.extrapolService.fillBuffer(buffer, this._bufferSnapshots);
+    }
 
     serverUpdate(buffer: IMatchData[], serverSnapshot: IMatchData,
                     currentSnapshot: IMatchData): void {

--- a/frontend/src/app/game/services/prediction.service.ts
+++ b/frontend/src/app/game/services/prediction.service.ts
@@ -1,0 +1,335 @@
+import { Injectable } from "@angular/core";
+import { IBallData } from "../elements/Ball";
+
+export interface    IPredictionInit {
+    gameWidth: number;
+    gameHeight: number;
+    paddleWidth: number;
+    paddleHeight: number;
+    aPaddleX: number;
+    bPaddleX: number;
+    ballRadius: number;
+    //heroInit?: IHeroPredictionInit;
+}
+
+export interface    IPredictionInput {
+    fromTime: number;
+    toTime: number;
+    aPaddleY: number;
+    bPaddleY: number;
+    ball: IBallData;
+    /*aHero?: IHeroData;
+    bHero?: IHeroData;*/
+}
+
+export interface   IPredictionOutput {
+    ball: IBallData;
+    /*aHero?: IHeroData;
+    bHero?: IHeroData;*/
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class    PredictionService {
+
+    private _init: boolean;
+    private _gameWidth: number;
+    private _gameHeight: number;
+    private _paddleWidth: number;
+    private _paddleHeight: number;
+    private _paddleHalfWidth: number;
+    private _paddleHalfHeight: number;
+    private _aPaddleX: number;
+    private _aPaddleRightBorder: number;
+    private _bPaddleX: number;
+    private _bPaddleLeftBorder: number;
+    private _ballRadius: number;
+    private _ballX: number;
+    private _ballY: number;
+    private _ballVelocityX: number;
+    private _ballVelocityY: number;
+
+    constructor(
+        //private readonly heroPredictor: HeroPredictionService
+    ) {
+        this._init = false;
+        this._gameWidth = 0;
+        this._gameHeight = 0;
+        this._paddleWidth = 0;
+        this._paddleHeight = 0;
+        this._paddleHalfWidth = 0;
+        this._paddleHalfHeight = 0;
+        this._aPaddleX = 0;
+        this._bPaddleX = 0;
+        this._aPaddleRightBorder = 0;
+        this._bPaddleLeftBorder = 0;
+        this._ballRadius = 0;
+        this._ballX = 0;
+        this._ballY = 0;
+        this._ballVelocityX = 0;
+        this._ballVelocityY = 0;
+    }
+
+    init(data: IPredictionInit): void {
+        if (!data)
+        {
+            this._init = false;
+            //this.heroPredictor.init(data);
+            return ;
+        }
+        this._init = true;
+        this._gameWidth = data.gameWidth;
+        this._gameHeight = data.gameHeight;
+        this._paddleWidth = data.paddleWidth;
+        this._paddleHeight = data.paddleHeight;
+        this._paddleHalfWidth = this._paddleWidth / 2;
+        this._paddleHalfHeight = data.paddleHeight / 2;
+        this._aPaddleX = data.aPaddleX;
+        this._bPaddleX = data.bPaddleX;
+        this._aPaddleRightBorder = this._aPaddleX + this._paddleHalfWidth;
+        this._bPaddleLeftBorder = this._bPaddleX - this._paddleHalfWidth;
+        this._ballRadius = data.ballRadius;
+        //this.heroPredictor.init(data.heroInit);
+    }
+
+    private move(xDisplacement: number, yDisplacement: number): void {
+        this._ballX += xDisplacement;
+        this._ballY += yDisplacement;
+    }
+
+    private checkCollisionUp(xDisplacement: number,
+                                yDisplacement: number): boolean {
+        const   noCollisionDest: number = this._ballY - this._ballRadius
+                                            + yDisplacement;
+        
+        if (noCollisionDest <= 0)
+        {
+            this._ballX += xDisplacement;
+            this._ballY = (noCollisionDest * -1) + this._ballRadius;
+            this._ballVelocityY *= -1;
+            return (true);
+        }
+        return (false);
+    }
+
+    private checkCollisionDown(gameHeight: number, xDisplacement: number,
+                                yDisplacement: number): boolean {
+        if (this._ballY + this._ballRadius + yDisplacement >= gameHeight)
+        {
+            this._ballX += xDisplacement;
+            this._ballY = gameHeight - (this._ballY + yDisplacement + this._ballRadius
+                        - gameHeight) - this._ballRadius;
+            this._ballVelocityY *= -1;
+            return (true);
+        }
+        return (false);
+    }
+
+    private checkCollisionRight(gameWidth: number, gameHeight: number,
+                                    xDisplacement: number): boolean {
+        if (this._ballX + this._ballRadius + xDisplacement >= gameWidth)
+        {
+            this._ballVelocityX = 0;
+            this._ballVelocityY = 0;
+            this._ballX = (gameWidth / 2) - this._ballRadius;
+            this._ballY = (gameHeight / 2) - this._ballRadius;
+            return (true);
+        }
+        return (false);
+    }
+
+    private checkCollisionLeft(gameWidth: number, gameHeight: number,
+                                xDisplacement: number): boolean {
+        if (this._ballX - this._ballRadius + xDisplacement <= 0)
+        {
+            this._ballVelocityX = 0;
+            this._ballVelocityY = 0;
+            this._ballX = (gameWidth / 2) - this._ballRadius;
+            this._ballY = (gameHeight / 2) - this._ballRadius;
+            return (true);
+        }
+        return (false);
+    }
+
+    private paddleBounceX(xNoCollisionDest: number, prevVelocityX: number,
+                            paddleBorder: number): number {
+        const   bounceAmount: number = (xNoCollisionDest - paddleBorder) * -1;
+        let     result: number = paddleBorder;
+
+        if (prevVelocityX === this._ballVelocityX * -1)
+            result += bounceAmount;
+        else
+        {
+            // Rule of Three
+            result += ((this._ballVelocityX * bounceAmount) / prevVelocityX) * -1;
+        }
+        return (result);
+    }
+
+    private paddleBounceY(yDisplacement: number, prevVelocityY: number,
+                            yIntersection: number): number {
+        const   noCollisionDest: number = this._ballY + yDisplacement;
+        const   bounceAmount: number = (noCollisionDest - yIntersection);
+        let     result: number = yIntersection;
+
+        // Rule of Three
+        result += (this._ballVelocityY * bounceAmount) / prevVelocityY;
+        return (result);
+    }
+
+    private collisionPaddleLeft(paddleY: number, yIntersection: number,
+                                    xNoCollisionDest: number,
+                                    yDisplacement: number): void {
+        const   prevVelocityX: number = this._ballVelocityX;
+        const   prevVelocityY: number = this._ballVelocityY;
+        const   ballHitVelocity = 300;
+        const   paddleHitHeight = yIntersection - paddleY
+                                    + this._paddleHalfHeight;
+    
+        this._ballVelocityX = ballHitVelocity;
+        this._ballVelocityY = ((paddleHitHeight / this._paddleHeight)
+                            * (ballHitVelocity * 2))
+                            - ballHitVelocity;
+        this._ballX = this.paddleBounceX(xNoCollisionDest, prevVelocityX,
+                                        this._aPaddleRightBorder)
+                                    + this._ballRadius;
+        this._ballY = this.paddleBounceY(yDisplacement, prevVelocityY,
+                                        yIntersection);
+    }
+
+    private collisionPaddleRight(paddleY: number, yIntersection: number,
+                                    xNoCollisionDest: number,
+                                    yDisplacement: number): void {
+        const   prevVelocityX: number = this._ballVelocityX;
+        const   prevVelocityY: number = this._ballVelocityY;
+        const   ballHitVelocity = 300;
+        const   paddleHitHeight = yIntersection - paddleY
+                                    + this._paddleHalfHeight;
+        
+        this._ballVelocityX = ballHitVelocity;
+        this._ballVelocityY = ((paddleHitHeight / this._paddleHeight)
+                            * (ballHitVelocity * 2))
+                            - ballHitVelocity;
+        this._ballVelocityX *= -1;
+        this._ballX = this.paddleBounceX(xNoCollisionDest, prevVelocityX,
+                                        this._bPaddleLeftBorder)
+                                    - this._ballRadius;
+        this._ballY = this.paddleBounceY(yDisplacement, prevVelocityY,
+                                        yIntersection);
+    }
+
+    private yIntersectionPoint(paddleX: number, xDisplacement: number,
+                                yDisplacement: number): number {
+        const   slope = yDisplacement / xDisplacement;
+    
+        return ((slope * (paddleX - this._ballX)) + this._ballY)
+    }
+
+    private checkPaddleCollisionLeft(aPaddleY: number, xDisplacement: number,
+                                        yDisplacement: number): boolean {
+        const   xNoCollisionDest: number = this._ballX - this._ballRadius
+                                            + xDisplacement;
+        let     yIntersection: number;
+    
+        if (xNoCollisionDest <= this._aPaddleRightBorder
+            && this._ballX - this._ballRadius > this._aPaddleRightBorder)
+        {
+            yIntersection = this.yIntersectionPoint(this._aPaddleRightBorder,
+                                                        xDisplacement,
+                                                        yDisplacement);
+            if (Math.abs(yIntersection - aPaddleY)
+                    <= this._paddleHalfHeight + this._ballRadius)
+            {
+                this.collisionPaddleLeft(aPaddleY, yIntersection,
+                                            xNoCollisionDest, yDisplacement);
+                return (true);
+            }
+        }
+        return (false);
+    }
+
+    private checkPaddleCollisionRight(bPaddleY: number, xDisplacement: number,
+                                        yDisplacement: number): boolean {
+        const   xNoCollisionDest: number = this._ballX + this._ballRadius
+                                            + xDisplacement;
+        let     yIntersection: number;
+
+        if (xNoCollisionDest >= this._bPaddleLeftBorder
+            && this._ballX + this._ballRadius < this._bPaddleLeftBorder)
+        {
+            yIntersection = this.yIntersectionPoint(this._bPaddleLeftBorder,
+                                                        xDisplacement,
+                                                        yDisplacement);
+            if (Math.abs(yIntersection - bPaddleY)
+                    <= this._paddleHalfHeight + this._ballRadius)
+            {
+                this.collisionPaddleRight(bPaddleY, yIntersection,
+                                            xNoCollisionDest, yDisplacement);
+                return (true);
+            }
+        }
+        return (false);
+    }
+
+    private checkCollision(data: IPredictionInput, xDisplacement: number,
+                            yDisplacement: number): boolean {
+        if (this._ballVelocityX < 0)
+        {
+            if (this.checkPaddleCollisionLeft(data.aPaddleY, xDisplacement,
+                                                yDisplacement))
+                return (true);
+            if (this.checkCollisionLeft(this._gameWidth, this._gameHeight,
+                                            xDisplacement))
+                return (true);
+        }
+        else if ((this._ballVelocityX > 0))
+        {
+            if (this.checkPaddleCollisionRight(data.bPaddleY, xDisplacement,
+                                                yDisplacement))
+                return (true);
+            if (this.checkCollisionRight(this._gameWidth, this._gameHeight,
+                                            xDisplacement))
+                return (true);
+        }
+        if (this.checkCollisionUp(xDisplacement, yDisplacement)
+            || this.checkCollisionDown(this._gameHeight,
+                                        xDisplacement, yDisplacement))
+            return (true);
+        return (false);
+    }
+
+    private displacement(velocity: number, seconds: number): number {
+        return (velocity * seconds);
+    }
+
+    private _processInput(data: IPredictionInput): void {
+        this._ballX = data.ball.xPos;
+        this._ballY = data.ball.yPos;
+        this._ballVelocityX = data.ball.xVel;
+        this._ballVelocityY = data.ball.yVel;
+    }
+
+    getSnapshot(data: IPredictionInput): IPredictionOutput | undefined {
+        const   secondsElapsed: number =
+                                (data.toTime - data.fromTime) / 1000;
+        const   xDisplacement: number = this.displacement(data.ball.xVel,
+                                                            secondsElapsed);
+        const   yDisplacement: number = this.displacement(data.ball.yVel,
+                                                            secondsElapsed);
+    
+        if (!data || !this._init)
+            return (undefined);        
+        this._processInput(data);
+        if (!this.checkCollision(data, xDisplacement, yDisplacement))
+            this.move(xDisplacement, yDisplacement);
+        return ({
+            ball: {
+                xPos: this._ballX,
+                yPos: this._ballY,
+                xVel: this._ballVelocityX,
+                yVel: this._ballVelocityY
+            },
+        });
+    }
+}


### PR DESCRIPTION
Añadidos servicios de extrapolación y predicción para la bola del juego. Además, se ha aumentado el intervalo de tiempo entre actualizaciones del servidor, y se ha aumentado el tamaño del buffer de snapshots a 3, ahora que se puede predecir la posición de la bola en el cliente.