### PR TITLE
Add immediate player input rendering

### DIFF
--- a/backend/src/game/elements/Hero.ts
+++ b/backend/src/game/elements/Hero.ts
@@ -11,6 +11,7 @@ export interface    IHeroData {
     lowXPos: number;
     lowYPos: number;
     active: number; //0: inactive, 1: lower, 2: upper
+    pointInvocation: boolean;
 }
 
 export interface    IHeroClientStart {
@@ -19,6 +20,7 @@ export interface    IHeroClientStart {
     sprite: ISprite;
     spriteLow: ISprite;
     active: number; //0: inactive, 1: lower, 2: upper
+    pointInvocation: boolean;
 }
 
 export interface    IHeroInit {
@@ -254,7 +256,8 @@ export class    Hero {
             yPos: this._upperSprite.yPos,
             lowXPos: this._lowerSprite.xPos,
             lowYPos: this._lowerSprite.yPos,
-            active: this._activeSprite
+            active: this._activeSprite,
+            pointInvocation: this._pointInvocation
         });
     }
 
@@ -264,7 +267,8 @@ export class    Hero {
             name: this._name,
             sprite: this._upperSprite,
             spriteLow: this._lowerSprite,
-            active: this._activeSprite
+            active: this._activeSprite,
+            pointInvocation: this._pointInvocation
         });
     }
 

--- a/backend/src/game/elements/Paddle.ts
+++ b/backend/src/game/elements/Paddle.ts
@@ -1,5 +1,3 @@
-import { arrayBuffer } from "stream/consumers";
-
 export interface    IPaddleInit {
     width: number;
     height: number;
@@ -14,6 +12,7 @@ export interface    IPaddleClientStart {
     xPos: number;
     yPos: number;
     color: number;
+    displacement: number; // In pixels
 }
 
 export class    Paddle {
@@ -27,6 +26,7 @@ export class    Paddle {
     private _side: number; //side: 0 === left, 1 === right
     private _xPos: number;
     private _yPos: number;
+    private _displacement: number;
 
     constructor(init: IPaddleInit) {
         this._width = init.width;
@@ -38,6 +38,7 @@ export class    Paddle {
         this._leftBorder = this._xPos - this._halfWidth;
         this._rightBorder = this._xPos + this._halfWidth;
         this._side = init.side;
+        this._displacement = 8;
     }
 
     get height(): number {
@@ -73,24 +74,24 @@ export class    Paddle {
     }
 
     up(): void {
-        if (this._yPos - 8 < this._halfHeight)
+        if (this._yPos - this._displacement < this._halfHeight)
             this._yPos = this._halfHeight;
         else
-            this._yPos -= 8;
+            this._yPos -= this._displacement;
     }
 
     down(gameHeight: number): void {
-        if (this._yPos + 8 > gameHeight - this.halfHeight)
+        if (this._yPos + this._displacement > gameHeight - this.halfHeight)
             this._yPos = gameHeight - this.halfHeight;
         else
-            this._yPos += 8;
+            this._yPos += this._displacement;
     }
 
     update(up: boolean, gameHeight: number): void {
-            if (up)
-                this.up();
-            else
-                this.down(gameHeight);
+        if (up)
+            this.up();
+        else
+            this.down(gameHeight);
     }
     
     clientStartData(): IPaddleClientStart {
@@ -99,7 +100,8 @@ export class    Paddle {
             height: this._height,
             xPos: this._xPos,
             yPos: this._yPos,
-            color: 0xffffff
+            color: 0xffffff,
+            displacement: this._displacement
         })
     }
 

--- a/frontend/src/app/game/elements/Hero.ts
+++ b/frontend/src/app/game/elements/Hero.ts
@@ -28,6 +28,7 @@ export interface    IHeroInitData {
     sprite: IHeroSprite;
     spriteLow: IHeroSprite;
     active: number; //0: inactive, 1: lower, 2: upper
+    pointInvocation: boolean;
 }
 
 export interface    IHeroData {
@@ -36,12 +37,14 @@ export interface    IHeroData {
     lowXPos: number;
     lowYPos: number;
     active: number; //0: inactive, 1: lower, 2: upper
+    pointInvocation: boolean;
 }
 
 export class    Hero {
     protected _upperSprite: Phaser.GameObjects.Sprite;
     protected _lowerSprite: Phaser.GameObjects.Sprite;
     protected _active: number;
+    protected _pointInvocation: boolean;
 
     constructor(scene: MatchScene, initData: IHeroInitData) {
         this._upperSprite = scene.add.sprite(
@@ -63,6 +66,7 @@ export class    Hero {
             initData.spriteLow.yOrigin
         );
         this._active = initData.active;
+        this._pointInvocation = initData.pointInvocation;
     }
 
     get data(): IHeroData {
@@ -71,7 +75,8 @@ export class    Hero {
             yPos: this._upperSprite.y,
             lowXPos: this._lowerSprite.x,
             lowYPos: this._lowerSprite.y,
-            active: this._active
+            active: this._active,
+            pointInvocation: this._pointInvocation
         });
     }
 

--- a/frontend/src/app/game/elements/Paddle.ts
+++ b/frontend/src/app/game/elements/Paddle.ts
@@ -7,12 +7,16 @@ export interface    IPaddleInitData {
     width: number;
     height: number;
     color: number;
+    displacement: number;
 }
 
 export class    Paddle {
 
     private _paddle: Phaser.GameObjects.Rectangle;
     private _paddleShadow: Phaser.GameObjects.Rectangle;
+
+    private static _displacement: number;
+    private static _halfHeight: number;
 
     constructor(scene: MatchScene, initData: IPaddleInitData) {
         this._paddle = scene.add.rectangle(
@@ -31,6 +35,8 @@ export class    Paddle {
         );
         this._paddle.depth = 1;
         this._paddleShadow.depth = 0;
+        Paddle._displacement = initData.displacement;
+        Paddle._halfHeight = initData.height / 2;
     }
 
     get xPos(): number {
@@ -39,6 +45,26 @@ export class    Paddle {
 
     get yPos(): number {
         return (this._paddle.y);
+    }
+
+    static  moveUp(paddleY: number): number {
+        let result: number;
+    
+        if (paddleY - this._displacement < this._halfHeight)
+            result = this._halfHeight;
+        else
+            result = paddleY - this._displacement;
+        return (result);
+    }
+
+    static  moveDown(paddleY: number, gameHeight: number): number {
+        let result: number;
+    
+        if (paddleY + this._displacement > gameHeight - this._halfHeight)
+            result = gameHeight - this._halfHeight;
+        else
+            result = paddleY + this._displacement;
+        return (result);
     }
 
     update(yPos: number): void {

--- a/frontend/src/app/game/elements/SnapshotBuffer.ts
+++ b/frontend/src/app/game/elements/SnapshotBuffer.ts
@@ -4,33 +4,40 @@ import {
 } from "./Match";
 import { LagCompensationService } from "../services/lag-compensation.service";
 
+export interface    IBufferInit {
+    gameWidth: number;
+    gameHeight: number;
+    matchData: IMatchInitData;
+    role: string;
+}
+
 export class   SnapshotBuffer {
 
     private _buffer: IMatchData[];
 
     constructor(
-        gameWidth: number,
-        gameHeight: number,
-        initData: IMatchInitData,
+        initData: IBufferInit,
         private readonly lagCompensator: LagCompensationService
     ) {
+        const   matchData: IMatchInitData = initData.matchData;
+    
         this._buffer = [];
         this.lagCompensator.init({
-            gameWidth: gameWidth,
-            gameHeight: gameHeight,
-            paddleWidth: initData.playerA.paddle.width,
-            paddleHeight: initData.playerA.paddle.height,
-            aPaddleX: initData.playerA.paddle.xPos,
-            bPaddleX: initData.playerB.paddle.xPos,
-            ballRadius: initData.ball.width / 2,
-            heroInit: initData.playerA.hero && initData.playerB.hero
+            gameWidth: initData.gameWidth,
+            gameHeight: initData.gameHeight,
+            paddleWidth: matchData.playerA.paddle.width,
+            paddleHeight: matchData.playerA.paddle.height,
+            aPaddleX: matchData.playerA.paddle.xPos,
+            bPaddleX: matchData.playerB.paddle.xPos,
+            ballRadius: matchData.ball.width / 2,
+            heroInit: matchData.playerA.hero && matchData.playerB.hero
                         ? {
-                            aHeroSprite: initData.playerA.hero.sprite,
-                            aHeroSpriteLow: initData.playerA.hero.spriteLow,
-                            bHeroSprite: initData.playerB.hero.sprite,
-                            bHeroSpriteLow: initData.playerB.hero.spriteLow
+                            aHeroSprite: matchData.playerA.hero.sprite,
+                            aHeroSpriteLow: matchData.playerA.hero.spriteLow,
+                            bHeroSprite: matchData.playerB.hero.sprite,
+                            bHeroSpriteLow: matchData.playerB.hero.spriteLow
                         } : undefined
-        });
+        }, initData.role);
     }
 
     get size(): number {
@@ -59,6 +66,14 @@ export class   SnapshotBuffer {
         }
         else
             this.lagCompensator.autoFill(this._buffer);
+    }
+
+    input(paddleMove: number, heroMove: number,
+            currentSnapshot: IMatchData | undefined): void {
+        if (!currentSnapshot)
+            return ;
+        this.lagCompensator.input(this._buffer, paddleMove,
+                                    heroMove, currentSnapshot);
     }
 
 }

--- a/frontend/src/app/game/scenes/ClassicPlayerScene.ts
+++ b/frontend/src/app/game/scenes/ClassicPlayerScene.ts
@@ -20,12 +20,22 @@ export class    ClassicPlayerScene extends MatchScene {
         super.create();
     }
 
-    override update() {    
+    override update(time: number) {
+        let input: number = 0;
+    
         if (this.cursors?.up.isDown)
+        {
             this.socket.emit('paddleUp');
+            input = 2;
+        }
         else if (this.cursors?.down.isDown)
+        {
             this.socket.emit('paddleDown');
-        super.update();
+            input = 1;
+        }
+        if (input)
+            this.buffer?.input(input, 0, this.match?.snapshot);
+        super.update(time);
     }
 
 }

--- a/frontend/src/app/game/scenes/MenuHeroScene.ts
+++ b/frontend/src/app/game/scenes/MenuHeroScene.ts
@@ -28,9 +28,19 @@ export class    MenuHeroScene extends MenuScene {
                 this._menuHeroRenderer.destroy();
             this.removeAllSocketListeners();
             if (this.role != "Spectator")
-                this.scene.start("Player", gameData);
+            {
+                this.scene.start("Player", {
+                    role: this.role,
+                    matchData: gameData
+                });
+            }
             else
-                this.scene.start(this.role, gameData);
+            {
+                this.scene.start(this.role, {
+                    role: this.role,
+                    matchData: gameData
+                });
+            }
         });
         this.socket.once("end", (data) => {
             if (this._menuHeroRenderer)

--- a/frontend/src/app/game/scenes/MenuScene.ts
+++ b/frontend/src/app/game/scenes/MenuScene.ts
@@ -48,9 +48,19 @@ export class    MenuScene extends BaseScene {
                 this._menuRenderer.destroy();
             this.removeAllSocketListeners();
             if (this.role != "Spectator")
-                this.scene.start("ClassicPlayer", gameData);
+            {
+                this.scene.start("ClassicPlayer", {
+                    role: this.role,
+                    matchData: gameData
+                });
+            }
             else
-                this.scene.start(this.role, gameData);
+            {
+                this.scene.start(this.role, {
+                    role: this.role,
+                    matchData: gameData
+                });
+            }
         });
         this.socket.once("end", (data) => {
             if (this._menuRenderer)

--- a/frontend/src/app/game/scenes/PlayerScene.ts
+++ b/frontend/src/app/game/scenes/PlayerScene.ts
@@ -25,16 +25,32 @@ export class    PlayerScene extends MatchScene {
         super.create();
     }
 
-    override update() {
+    override update(time: number) {
+        let input: [paddleUp: number, heroUp: number] = [0, 0];
+    
         if (this.cursors?.up.isDown)
+        {
             this.socket.emit('paddleUp');
+            input[0] = 2;
+        }
         else if (this.cursors?.down.isDown)
+        {
             this.socket.emit('paddleDown');
+            input[0] = 1;
+        }
         if (this.powerKeys.up.isDown)
+        {
             this.socket.emit('heroUp');
+            input[1] = 2;
+        }
         else if (this.powerKeys.down.isDown)
+        {
             this.socket.emit('heroDown');
-        super.update();
+            input[1] = 1;
+        }
+        if (input[0] || input[1])
+            this.buffer?.input(input[0], input[1], this.match?.snapshot);
+        super.update(time);
     }
 
 }

--- a/frontend/src/app/game/scenes/StartScene.ts
+++ b/frontend/src/app/game/scenes/StartScene.ts
@@ -1,7 +1,6 @@
 import * as SocketIO from 'socket.io-client'
 import { IMatchInitData } from '../elements/Match';
 import { StartTitles } from '../elements/StartTitles';
-import { Txt } from '../elements/Txt';
 import { BaseScene } from './BaseScene'
 import { IMenuInit } from './MenuScene';
 
@@ -27,7 +26,10 @@ export class    StartScene extends BaseScene {
         this.socket.once("startMatch", (gameData: IMatchInitData) => {
             this.startTitles?.destroy();
             this.removeAllSocketListeners();
-            this.scene.start("Spectator", gameData);
+            this.scene.start("Spectator", {
+                role: "Spectator",
+                matchData: gameData
+            });
         });
         this.socket.once("end", (data: any) => {
             this.startTitles?.destroy();

--- a/frontend/src/app/game/services/extrapolation.service.ts
+++ b/frontend/src/app/game/services/extrapolation.service.ts
@@ -67,8 +67,8 @@ export class    ExtrapolationService {
     **  snapshots with.
     */
     fillBuffer(buffer: IMatchData[], totalSnapshots: number): void {
-        let     generatedSnapshot: IMatchData;
-        let     refSnapshot: IMatchData;
+        let generatedSnapshot: IMatchData;
+        let refSnapshot: IMatchData;
 
         if (!buffer.length)
             return ;
@@ -81,6 +81,46 @@ export class    ExtrapolationService {
                 Math.round(refSnapshot.when + this._snapshotInterval)
             );
             buffer.push(generatedSnapshot);
+        }
+    }
+
+    private _preserveUnpredictable(current: IMatchData,
+                                    prediction: IMatchData,
+                                    role: string): void {        
+        current.ball = {...prediction.ball};
+        current.when = prediction.when;
+        if (role === "PlayerA")
+        {
+            current.playerA.paddleY = prediction.playerA.paddleY;
+            if (prediction.playerA.hero)
+                current.playerA.hero = {...prediction.playerA.hero};
+        }
+        else
+        {
+            current.playerB.paddleY = prediction.playerB.paddleY;
+            if (prediction.playerB.hero)
+                current.playerB.hero = {...prediction.playerB.hero};
+        }
+    }
+
+    updateInput(buffer: IMatchData[], baseSnapshot: IMatchData,
+                    totalSnapshots: number, role: string): void {
+        let generatedSnapshot: IMatchData;
+        let refSnapshot: IMatchData;
+
+        this._totalSnapshots = totalSnapshots;
+        refSnapshot = baseSnapshot;
+        for (let i = 0; i < this._totalSnapshots; ++i)
+        {
+            generatedSnapshot = this._getSnapshot(
+                refSnapshot,
+                Math.round(refSnapshot.when + this._snapshotInterval)
+            );
+            if (i < buffer.length)
+                this._preserveUnpredictable(buffer[i], generatedSnapshot, role);
+            else
+                buffer.push(Match.copyMatchData(generatedSnapshot));
+            refSnapshot = Match.copyMatchData(generatedSnapshot);
         }
     }
 

--- a/frontend/src/app/game/services/hero-prediction.service.ts
+++ b/frontend/src/app/game/services/hero-prediction.service.ts
@@ -149,11 +149,34 @@ export class    HeroPredictionService {
         return (undefined);
     }
 
+    private _checkEndPos(velocity: number,
+                            currentPosition: number,
+                            endPosition: number): boolean {
+        if (velocity < 0)
+        {
+            if (currentPosition <= endPosition)
+                return (true);
+        }
+        else if (velocity > 0)
+        {
+            if (currentPosition >= endPosition)
+                return (true);
+        }
+        else
+        {
+            if (currentPosition === endPosition)
+                return (true);
+        }
+        return (false);
+    }
+
     private _updatePosition(hero: IHeroSprite,
                                 secondsElapsed: number): boolean {
         this._xPos += secondsElapsed * hero.xVelocity;
         this._yPos += secondsElapsed * hero.yVelocity;
-        if (this._xPos === hero.xPosEnd && this._yPos === hero.yPosEnd)
+
+        if (this._checkEndPos(hero.xVelocity, this._xPos, hero.xPosEnd)
+                && this._checkEndPos(hero.yVelocity, this._yPos, hero.yPosEnd))
         {
             this._xPos = hero.xPosInit;
             this._yPos = hero.yPosInit;

--- a/frontend/src/app/game/services/interpolation.service.spec.ts
+++ b/frontend/src/app/game/services/interpolation.service.spec.ts
@@ -49,13 +49,18 @@ describe('InterpolationService', () => {
         const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   totalSnapshots: number = 3;
+        const   role: string = "Spectator";
     
         buffer = [];
         serverSnapshot.ball.xPos = 415;
         serverSnapshot.ball.yPos = 315;
         serverSnapshot.when = 1000 / 20;
-        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
-                            totalSnapshots);
+        service.fillBuffer(buffer, {
+            serverSnapshot: serverSnapshot,
+            currentSnapshot: currentSnapshot,
+            totalSnapshots: totalSnapshots,
+            role: role
+        });
         expect(buffer.length).toBe(3);
         expect(buffer[0].ball.xPos).toBe(405);
         expect(buffer[1].ball.xPos).toBe(410);
@@ -67,6 +72,7 @@ describe('InterpolationService', () => {
         const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   totalSnapshots: number = 3;
+        const   role: string = "Spectator";
         const   interval: number = 1000 / 60;
     
         buffer = [];
@@ -78,8 +84,12 @@ describe('InterpolationService', () => {
         serverSnapshot.ball.yPos = 315;
         serverSnapshot.playerA.paddleY = 500;
         serverSnapshot.when = interval * 3;
-        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
-                            totalSnapshots);
+        service.fillBuffer(buffer, {
+            serverSnapshot: serverSnapshot,
+            currentSnapshot: currentSnapshot,
+            totalSnapshots: totalSnapshots,
+            role: role
+        });
         expect(buffer.length).toBe(3);
         expect(buffer[0].ball.xPos).toBe(405);
         expect(buffer[0].playerA.paddleY).toBeGreaterThan(
@@ -100,6 +110,7 @@ describe('InterpolationService', () => {
         const   serverSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   currentSnapshot: IMatchData = Match.copyMatchData(sampleMatch);
         const   totalSnapshots: number = 3;
+        const   role: string = "Spectator";
         const   interval: number = 1000 / 60;
         let     bufferSnapshot: IMatchData;
     
@@ -112,8 +123,12 @@ describe('InterpolationService', () => {
         serverSnapshot.ball.xPos = 415;
         serverSnapshot.ball.yPos = 315;
         serverSnapshot.when = interval * 3;
-        service.fillBuffer(buffer, serverSnapshot, currentSnapshot,
-                            totalSnapshots);
+        service.fillBuffer(buffer, {
+            serverSnapshot: serverSnapshot,
+            currentSnapshot: currentSnapshot,
+            totalSnapshots: totalSnapshots,
+            role: role
+        });
         expect(buffer.length).toBe(3);
         expect(buffer[0].ball.xPos).toBe(405);
         expect(buffer[0].when).toBe(currentSnapshot.when + interval);

--- a/frontend/src/app/game/services/lag-compensation.service.ts
+++ b/frontend/src/app/game/services/lag-compensation.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from "@angular/core";
 import { IMatchData } from "../elements/Match";
+import { Paddle } from "../elements/Paddle";
+import { IPlayerData } from "../elements/Player";
 import { ExtrapolationService } from "./extrapolation.service";
 import { InterpolationService } from "./interpolation.service";
 import { IPredictionInit } from "./prediction.service";
@@ -11,13 +13,21 @@ export class    LagCompensationService {
 
     private readonly _bufferSnapshots: number = 3;
 
+    private _role: string;
+    private _gameHeight: number;
+
     constructor(
         private readonly interpolService: InterpolationService,
         private readonly extrapolService: ExtrapolationService
-    ) {}
+    ) {
+        this._role = "";
+        this._gameHeight = 0;
+    }
 
-    init(initData: IPredictionInit): void {
+    init(initData: IPredictionInit, role: string): void {
         this.extrapolService.init(initData);
+        this._role = role;
+        this._gameHeight = initData.gameHeight;
     }
 
     autoFill(buffer: IMatchData[]): void {
@@ -26,12 +36,41 @@ export class    LagCompensationService {
 
     serverUpdate(buffer: IMatchData[], serverSnapshot: IMatchData,
                     currentSnapshot: IMatchData): void {
-        this.interpolService.fillBuffer(
-            buffer,
-            serverSnapshot,
-            currentSnapshot,
-            this._bufferSnapshots
-        );
+        this.interpolService.fillBuffer(buffer, {
+            serverSnapshot: serverSnapshot,
+            currentSnapshot: currentSnapshot,
+            totalSnapshots: this._bufferSnapshots,
+            role: this._role
+        });
+    }
+
+    private _inputPaddle(playerData: IPlayerData, move: number): void {
+        if (!move)
+            return ;
+        playerData.paddleY = move === 1
+                                ? Paddle.moveDown(playerData.paddleY,
+                                                    this._gameHeight)
+                                : Paddle.moveUp(playerData.paddleY);
+    }
+
+    private _inputHero(playerData: IPlayerData, move: number): void {
+        if (!move || !playerData.hero || playerData.hero.pointInvocation
+                || playerData.hero.active)
+            return ;
+        playerData.hero.active = move;
+        playerData.hero.pointInvocation = false; //Leaving it false for testing
+    }
+
+    input(buffer: IMatchData[], paddleMove: number, heroMove: number,
+            currentSnapshot: IMatchData): void {
+        const   playerData: IPlayerData = this._role === "PlayerA"
+                                            ? currentSnapshot.playerA
+                                            : currentSnapshot.playerB;
+    
+        this._inputPaddle(playerData, paddleMove);
+        this._inputHero(playerData, heroMove);
+        this.extrapolService.updateInput(buffer, currentSnapshot,
+                                            this._bufferSnapshots, this._role);
     }
 
 }


### PR DESCRIPTION
Añadido renderizado inmediato del input del jugador.

Para ello, se pasa el rol del usuario en la partida (Jugador A, Jugador B, Espectador) a los servicios de actualización de la partida para saber si la información de cada jugador que viene del servidor se aplica o no. En caso de que el usuario tenga un rol de jugador, se actualizará la información de su paleta y héroe cuando el cálculo provenga del cliente y no del servidor.