### PR TITLE
Render game state in real-time for players

### DIFF
--- a/frontend/src/app/game/elements/Match.ts
+++ b/frontend/src/app/game/elements/Match.ts
@@ -66,7 +66,7 @@ export class    Match {
     }
 
     // Returns a Deep Copy of IPlayerData
-    private static _copyPlayer(data: IPlayerData): IPlayerData {
+    private static _clonePlayer(data: IPlayerData): IPlayerData {
         return ({
             paddleY: data.paddleY,
             hero: data.hero ? {...data.hero} : undefined,
@@ -75,13 +75,20 @@ export class    Match {
     }
 
     // Returns a Deep Copy of IMatchData
-    static copyMatchData(data: IMatchData): IMatchData {
+    static cloneMatchData(data: IMatchData): IMatchData {
         return ({
             ball: {...data.ball},
-            playerA: this._copyPlayer(data.playerA),
-            playerB: this._copyPlayer(data.playerB),
+            playerA: this._clonePlayer(data.playerA),
+            playerB: this._clonePlayer(data.playerB),
             when: data.when
         });
+    }
+
+    static copyMatchData(dst: IMatchData, src: IMatchData): void {
+        dst.ball = {...src.ball};
+        dst.playerA = this._clonePlayer(src.playerA);
+        dst.playerB = this._clonePlayer(src.playerB);
+        dst.when = src.when;
     }
 
     get snapshot(): IMatchData {    

--- a/frontend/src/app/game/services/hero-prediction.service.ts
+++ b/frontend/src/app/game/services/hero-prediction.service.ts
@@ -35,6 +35,9 @@ export class    HeroPredictionService {
     private _xPos: number;
     private _yPos: number;
 
+    private static _aHeroEndX: number = 0;
+    private static _bHeroEndX: number = 0;
+
     constructor() {
         this._init = false;
         this._aHero = {} as IHeroSprite;
@@ -43,6 +46,14 @@ export class    HeroPredictionService {
         this._bHeroLow = {} as IHeroSprite;
         this._xPos = 0;
         this._yPos = 0;
+    }
+
+    static get aHeroEndX(): number {
+        return (this._aHeroEndX);
+    }
+
+    static get bHeroEndX(): number {
+        return (this._bHeroEndX);
     }
 
     init(data: IHeroPredictionInit | undefined): void {
@@ -56,6 +67,10 @@ export class    HeroPredictionService {
         this._aHeroLow = {...data.aHeroSpriteLow};
         this._bHero = {...data.bHeroSprite};
         this._bHeroLow = {...data.bHeroSpriteLow};
+        HeroPredictionService._aHeroEndX = this._aHero.xPosEnd
+                                            + this._aHero.radius;
+        HeroPredictionService._bHeroEndX = this._bHero.xPosEnd
+                                            - this._bHero.radius;
     }
 
     private _ballHitBounce(posNoCollision: number, posCollision: number,
@@ -185,26 +200,28 @@ export class    HeroPredictionService {
         return (true);
     }
 
-    move(heroData: IHeroData, aHero: boolean, secondsElapsed: number): void {
+    move(heroData: IHeroData, aHero: boolean,
+            secondsElapsed: number): IHeroData {
         const   hero: IHeroSprite | undefined = this._getHero(heroData, aHero);
+        const   result: IHeroData = {...heroData};
         let     active: boolean;
 
         if (!this._init || !hero)
-            return ;
+            return (result);
         active = this._updatePosition(hero, secondsElapsed);
         if (heroData.active === 1)
         {
-            heroData.lowXPos = this._xPos;
-            heroData.lowYPos = this._yPos;
+            result.lowXPos = this._xPos;
+            result.lowYPos = this._yPos;
         }
         else
         {
-            heroData.xPos = this._xPos;
-            heroData.yPos = this._yPos;
+            result.xPos = this._xPos;
+            result.yPos = this._yPos;
         }
         if (!active)
-            heroData.active = 0;
-        return ;
+            result.active = 0;
+        return (result);
     }
 
 }

--- a/frontend/src/app/game/services/prediction.service.ts
+++ b/frontend/src/app/game/services/prediction.service.ts
@@ -57,6 +57,9 @@ export class    PredictionService {
     private _ballVelocityX: number;
     private _ballVelocityY: number;
 
+    private static _aPaddleRightBorder: number = 0;
+    private static _bPaddleLeftBorder: number = 0;
+
     constructor(
         private readonly heroPredictor: HeroPredictionService
     ) {
@@ -76,6 +79,14 @@ export class    PredictionService {
         this._ballY = 0;
         this._ballVelocityX = 0;
         this._ballVelocityY = 0;
+    }
+
+    static get aPaddleRightBorder(): number {
+        return (this._aPaddleRightBorder);
+    }
+
+    static get bPaddleLeftBorder(): number {
+        return (this._bPaddleLeftBorder);
     }
 
     init(data: IPredictionInit): void {
@@ -98,6 +109,8 @@ export class    PredictionService {
         this._bPaddleLeftBorder = this._bPaddleX - this._paddleHalfWidth;
         this._ballRadius = data.ballRadius;
         this.heroPredictor.init(data.heroInit);
+        PredictionService._aPaddleRightBorder = this._aPaddleRightBorder;
+        PredictionService._bPaddleLeftBorder = this._bPaddleLeftBorder;
     }
 
     private move(xDisplacement: number, yDisplacement: number): void {
@@ -375,10 +388,6 @@ export class    PredictionService {
         if (!this.checkCollision(data, xDisplacement, yDisplacement,
                 secondsElapsed))
             this.move(xDisplacement, yDisplacement);
-        if (data.aHero)
-            this.heroPredictor.move(data.aHero, true, secondsElapsed);
-        if (data.bHero)
-            this.heroPredictor.move(data.bHero, false, secondsElapsed);
         return ({
             ball: {
                 xPos: this._ballX,
@@ -386,8 +395,12 @@ export class    PredictionService {
                 xVel: this._ballVelocityX,
                 yVel: this._ballVelocityY
             },
-            aHero: data.aHero,
+            aHero: data.aHero
+                    ? this.heroPredictor.move(data.aHero, true, secondsElapsed)
+                    : undefined,
             bHero: data.bHero
+                    ? this.heroPredictor.move(data.bHero, false, secondsElapsed)
+                    : undefined
         });
     }
 }


### PR DESCRIPTION
Implementación de renderizado de la bola en tiempo real para los jugadores cuando ésta se dirige hacia ellos y está fuera del alcance del área de influencia del jugador contrario.

Para conseguir esto, se extrapola de forma "agresiva" (más allá del momento actual), cuando la bola se dirige hacia el jugador, y se interpola, con extrapolación de refuerzo para mantener las reglas físicas, cuando la bola se dirige hacia el jugador contrario. Los espectadores no extrapolan de forma "agresiva" en ningún momento.