### PR TITLE
Fix ranking column type at user entity

### DIFF
--- a/backend/src/user/entities/user.entity.ts
+++ b/backend/src/user/entities/user.entity.ts
@@ -113,7 +113,6 @@ export class UserEntity extends BaseEntity {
 	acceptedTerms: boolean;
 
 	@Column({
-		type: 'bigint',
 		default: 1500
 	})
 	ranking: number;


### PR DESCRIPTION
El problema está en que el tipo de columna 'bigint' de las bases de datos SQL no cabe en una variable de tipo number en JavaScript, y TypeORM lo convierte a un string.

Pienso que se podría quitar el tipo 'bigint' para esta columna. Pero si queremos mantenerlo habría que hacer conversiones al operar con ella.

https://stackoverflow.com/questions/59927625/how-to-store-big-int-in-nest-js-using-typeorm
https://typeorm.io/entities#column-types

Resolves #13 