### PR TITLE
Add game recovery services for changes in tab focus

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -18,6 +18,7 @@ import { DefaultEventsMap } from 'socket.io/dist/typed-events';
 import { IGameClientStart } from './elements/Game'
 import { IGameSelectionData } from './elements/GameSelection';
 import { GameQueueService } from './game.queueService';
+import { GameRecoveryService } from './game.recovery.service';
 import { SocketHelper } from './game.socket.helper';
 import { GameUpdateService } from './game.updateService';
 
@@ -35,7 +36,8 @@ export class    GameGateway implements OnGatewayInit,
     constructor(
         private readonly updateService: GameUpdateService,
         private readonly queueService: GameQueueService,
-        private readonly socketHelper: SocketHelper
+        private readonly socketHelper: SocketHelper,
+        private readonly recoveryService: GameRecoveryService
     ) {}
   
     afterInit() {
@@ -204,6 +206,14 @@ export class    GameGateway implements OnGatewayInit,
         const   [room, player] = this.socketHelper.getClientRoomPlayer(client);
 
         this.updateService.heroInput(room, player, false, when);
+    }
+
+    @SubscribeMessage('recover')
+    recover(
+        @ConnectedSocket() client: Socket,
+        @MessageBody() roomId: string
+    ) {
+        this.recoveryService.recover(client, roomId);
     }
 
   }

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -7,6 +7,7 @@ import { GameGateway } from './game.gateway';
 import { GameQueueService } from './game.queueService';
 import { GameRankingService } from './game.rankingService';
 import { GameReconciliationService } from './game.reconciliation.service';
+import { GameRecoveryService } from './game.recovery.service';
 import { GameService } from './game.service';
 import { SocketHelper } from './game.socket.helper';
 import { GameUpdateService } from './game.updateService';
@@ -25,7 +26,8 @@ import { GameUpdateService } from './game.updateService';
     GameUpdateService,
     GameRankingService,
     GameReconciliationService,
-    SocketHelper
+    SocketHelper,
+    GameRecoveryService,
   ],
 })
 export class GameModule {}

--- a/backend/src/game/game.recovery.service.ts
+++ b/backend/src/game/game.recovery.service.ts
@@ -1,0 +1,125 @@
+import { Injectable } from "@nestjs/common";
+import { Socket } from "socket.io";
+import { IGameClientStart } from "./elements/Game";
+import { IGameSelectionData } from "./elements/GameSelection";
+import { SocketHelper } from "./game.socket.helper";
+import {
+    GameUpdateService,
+    IGameResultData
+} from "./game.updateService";
+
+export type SceneId =
+                | "start"
+                | "menuClassic"
+                | "menuHero"
+                | "match"
+                | "end";
+
+export interface    IRecoverData {
+    readonly scene: SceneId;
+    readonly data:
+                | IMenuInit
+                | IGameClientStart
+                | IGameResultData
+                | undefined;
+}
+
+export interface    IMenuInit {
+    hero: boolean;
+    role: GameRole;
+    selection: IGameSelectionData;
+}
+
+export type GameRole = "Spectator" | "PlayerA" | "PlayerB";
+
+@Injectable()
+export class    GameRecoveryService {
+
+    constructor(
+        private readonly updateService: GameUpdateService,
+        private readonly socketHelper: SocketHelper
+    ) {}
+
+    private _isSelection(
+                data: IMenuInit | IGameClientStart
+                        | IGameResultData | undefined): boolean {
+        return (
+            (data as IMenuInit).selection !== undefined
+        );
+    }
+
+    private _isMatch(
+                data: IMenuInit | IGameClientStart
+                        | IGameResultData | undefined): boolean {
+        return (
+            (data as IGameClientStart).ball !== undefined
+        );
+    }
+
+    private _getScene(data: IMenuInit | IGameClientStart
+                                | IGameResultData | undefined): SceneId {
+        if (data === undefined)
+            return ("start");
+        if (this._isSelection(data))
+        {
+            if ((data as IMenuInit).hero === true)
+                return ("menuHero")
+            return ("menuClassic");
+        }
+        if (this._isMatch(data))
+            return ("match");
+        return ("end");
+    }
+
+    private _getRole(client: Socket): GameRole {
+        const   [, player]: [string | undefined, any] =
+                    this.socketHelper.getClientRoomPlayer(client); //Improve!! return GameRole or undefined in second value
+        let     role: GameRole = "Spectator";
+
+        if (player)
+            role = player;
+        return (role);
+    }
+
+    private _getData(client: Socket, roomId: string)
+                : IMenuInit | IGameClientStart
+                    | IGameResultData | undefined {
+        let selectionData: IGameSelectionData;
+        let matchData: IGameClientStart;
+        let result: IGameResultData;
+
+        selectionData = this.updateService.getGameSelectionData(roomId);
+        if (selectionData)
+        {
+            return ({
+                hero: selectionData.heroA != undefined,
+                role: this._getRole(client),
+                selection: selectionData
+            });
+        }
+        matchData = this.updateService.getGameClientStartData(roomId);
+        if (matchData)
+        {
+            return (matchData);
+        }
+        result = this.updateService.getGameResult(roomId);
+        if (result)
+        {
+            return (result);
+        }
+        return (undefined);
+    }
+
+    recover(client: Socket, roomId: string): void {
+        const   data: IMenuInit | IGameClientStart
+                        | IGameResultData | undefined =
+                    this._getData(client, roomId);
+        const   scene: SceneId = this._getScene(data);
+        
+        client.emit("recoverData", {
+            scene: scene,
+            data: data
+        } as IRecoverData);
+    }
+
+}

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -179,8 +179,6 @@ export class    GameService {
                     return ;
             }
         }
-        players[0] = undefined;
-        players[1] = undefined;
         return ;
     }
 

--- a/frontend/src/app/game/elements/Hero.ts
+++ b/frontend/src/app/game/elements/Hero.ts
@@ -80,6 +80,17 @@ export abstract class    Hero {
         return ({...this._data});
     }
 
+    static initToData(data: IHeroInitData): IHeroData {
+        return ({
+            xPos: data.sprite.xPos,
+            yPos: data.sprite.yPos,
+            lowXPos: data.spriteLow.xPos,
+            lowYPos: data.spriteLow.yPos,
+            active: data.active,
+            pointInvocation: data.pointInvocation
+        });
+    }
+
     private _updateRenderPosition(heroSprite: Phaser.GameObjects.Sprite,
                                     upper: boolean): void {
         heroSprite.x = upper ? this._data.xPos : this._data.lowXPos;

--- a/frontend/src/app/game/elements/Match.ts
+++ b/frontend/src/app/game/elements/Match.ts
@@ -103,6 +103,46 @@ export class    Match {
         dst.when = src.when;
     }
 
+    static initToData(data: IMatchInitData): IMatchData {
+        return ({
+            ball: {
+                xPos: data.ball.xPos,
+                yPos: data.ball.yPos,
+                xVel: data.ball.xVel,
+                yVel: data.ball.yVel
+            },
+            playerA: Player.initToData(data.playerA),
+            playerB: Player.initToData(data.playerB),
+            when: data.when
+        });
+    }
+
+    get nickA(): string {
+        return (this._playerA.nick);
+    }
+
+    get nickB(): string {
+        return (this._playerB.nick);
+    }
+
+    get stage(): StageName | undefined {
+        if (!this._stage)
+            return (undefined);
+        if (this._stage instanceof Atlantis)
+            return (StageName.Atlantis);
+        if (this._stage instanceof Metropolis)
+            return (StageName.Metropolis);
+        return (StageName.Wakanda);
+    }
+
+    get heroA(): string | undefined {
+        return (this._playerA.hero);
+    }
+
+    get heroB(): string | undefined {
+        return (this._playerB.hero);
+    }
+
     get snapshot(): IMatchData {    
         return ({
             playerA: this._playerA.data,
@@ -110,6 +150,10 @@ export class    Match {
             ball: this._ball.data,
             when: this._when
         });
+    }
+
+    stopPointTitle(): void {
+        this._pointTitle.stop();
     }
 
     update(data: IMatchData | undefined): void {

--- a/frontend/src/app/game/elements/Player.ts
+++ b/frontend/src/app/game/elements/Player.ts
@@ -68,8 +68,26 @@ export class    Player {
         return (this._nick);
     }
 
+    get hero(): string | undefined {
+        if (!this._hero)
+            return (undefined);
+        if (this._hero instanceof Aquaman)
+            return ("aquaman");
+        if (this._hero instanceof BlackPanther)
+            return ("blackPanther");
+        return ("superman");
+    }
+
     set score(s: number) {
         this._score = s;
+    }
+
+    static initToData(data: IPlayerInitData): IPlayerData {
+        return ({
+            paddleY: data.paddle.yPos,
+            hero: data.hero ? Hero.initToData(data.hero) : undefined,
+            score: data.score
+        })
     }
 
     update(data: IPlayerData): void {

--- a/frontend/src/app/game/elements/PointTitle.ts
+++ b/frontend/src/app/game/elements/PointTitle.ts
@@ -64,6 +64,11 @@ export class    PointTitle {
         });
     }
 
+    stop():void {
+        if (this._tween?.isPlaying())
+            this._tween.complete();
+    }
+
     destroy(): void {
         if (this._tween)
             this._tween.stop();

--- a/frontend/src/app/game/elements/SnapshotBuffer.ts
+++ b/frontend/src/app/game/elements/SnapshotBuffer.ts
@@ -76,4 +76,8 @@ export class   SnapshotBuffer {
                                     heroMove, currentSnapshot);
     }
 
+    empty(): void {
+        this._buffer = [];
+    }
+
 }

--- a/frontend/src/app/game/game.component.ts
+++ b/frontend/src/app/game/game.component.ts
@@ -11,6 +11,7 @@ import { StartScene } from "./scenes/StartScene";
 import { LagCompensationService } from "./services/lag-compensation.service";
 import { LoadService } from "./services/load.service";
 import { SocketService } from "./services/socket.service";
+import { GameRecoveryService } from "./services/recovery.service";
 import { SoundService } from "./services/sound.service";
 
 @Component({
@@ -28,7 +29,8 @@ export class    GameComponent implements OnInit {
         private readonly socketService: SocketService,
         private readonly lagCompensator: LagCompensationService,
         private readonly loadService: LoadService,
-        private readonly soundService: SoundService
+        private readonly soundService: SoundService,
+        private readonly recoveryService: GameRecoveryService
     ) {
         this.config = {
             type: Phaser.CANVAS,
@@ -52,23 +54,33 @@ export class    GameComponent implements OnInit {
 
     ngOnInit(): void {
         const   startScene: StartScene =
-                    new StartScene(this.socket, "Game1");
+                    new StartScene(this.socket, "Game1", this.recoveryService);
         const   menuScene: MenuScene =
-                    new MenuScene(this.socket, "Game1");
+                    new MenuScene(this.socket, "Game1", this.recoveryService);
         const   menuHeroScene: MenuHeroScene =
-                    new MenuHeroScene(this.socket, "Game1", this.soundService);
+                    new MenuHeroScene(this.socket, "Game1",
+                                        this.soundService,
+                                        this.recoveryService);
         const   playerScene: PlayerScene =
-                    new PlayerScene(this.socket, "Game1", this.lagCompensator,
-                                        this.loadService, this.soundService);
+                    new PlayerScene(this.socket, "Game1",
+                                        this.lagCompensator,
+                                        this.loadService,
+                                        this.soundService,
+                                        this.recoveryService);
         const   classicPlayerScene: ClassicPlayerScene =
                     new ClassicPlayerScene(this.socket, "Game1",
-                                        this.lagCompensator, this.loadService,
-                                        this.soundService);
+                                        this.lagCompensator,
+                                        this.loadService,
+                                        this.soundService,
+                                        this.recoveryService);
         const   spectatorScene: SpectatorScene =
-                    new SpectatorScene(this.socket, "Game1", this.lagCompensator,
-                                        this.loadService, this.soundService);
+                    new SpectatorScene(this.socket, "Game1",
+                                        this.lagCompensator,
+                                        this.loadService,
+                                        this.soundService,
+                                        this.recoveryService);
         const   endScene: EndScene =
-                    new EndScene(this.socket, "Game1");
+                    new EndScene(this.socket, "Game1", this.recoveryService);
             
         this.config.scene = [
             startScene, menuScene, menuHeroScene, playerScene,

--- a/frontend/src/app/game/scenes/BaseScene.ts
+++ b/frontend/src/app/game/scenes/BaseScene.ts
@@ -1,8 +1,11 @@
 import * as Phaser from 'phaser'
 import * as SocketIO from 'socket.io-client'
+import { IMatchInitData } from '../elements/Match';
+import { IResultData } from '../elements/Result';
 import { Txt } from '../elements/Txt';
+import { IMenuInit } from './MenuScene';
 
-export class    BaseScene extends Phaser.Scene {
+export abstract class    BaseScene extends Phaser.Scene {
 
     socket: SocketIO.Socket;
     room: string;
@@ -17,7 +20,7 @@ export class    BaseScene extends Phaser.Scene {
         this.room = room;
     }
 
-    removeAllSocketListeners() {
+    private removeAllSocketListeners(): void {
         this.socket.off("leftSelection");
         this.socket.off("rightSelection");
         this.socket.off("confirmSelection");
@@ -25,6 +28,32 @@ export class    BaseScene extends Phaser.Scene {
         this.socket.off("startMatch");
         this.socket.off("end");
         this.socket.off("matchUpdate");
+        this.socket.off("recoverData");
     }
+
+    private removeAllGameListeners(): void {
+        this.game.events.off("focus");
+    }
+
+    removeAllListeners(): void {
+        this.removeAllSocketListeners();
+        this.removeAllGameListeners();
+    }
+
+    private emitRecover(): void {
+        this.socket.emit("recover", this.room);
+    }
+
+    setUpRecovery(): void {
+        this.game.events.on("focus", () => {
+            this.emitRecover();
+        });
+    }
+
+    abstract destroy(): void;
+
+    abstract recover(data?: IMenuInit
+                                | IMatchInitData
+                                | IResultData): void;
 
 }

--- a/frontend/src/app/game/scenes/ClassicPlayerScene.ts
+++ b/frontend/src/app/game/scenes/ClassicPlayerScene.ts
@@ -2,6 +2,7 @@ import * as Phaser from 'phaser'
 import * as SocketIO from 'socket.io-client'
 import { LagCompensationService } from '../services/lag-compensation.service';
 import { LoadService } from '../services/load.service';
+import { GameRecoveryService } from '../services/recovery.service';
 import { SoundService } from '../services/sound.service';
 import { MatchScene } from './MatchScene';
 
@@ -13,9 +14,11 @@ export class    ClassicPlayerScene extends MatchScene {
         socket: SocketIO.Socket, room: string,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
-        override readonly soundService: SoundService
+        override readonly soundService: SoundService,
+        override readonly recoveryService: GameRecoveryService
     ) {
-        super("ClassicPlayer", socket, room, lagCompensator, loadService, soundService);
+        super("ClassicPlayer", socket, room,
+                lagCompensator, loadService, soundService, recoveryService);
     }
 
     override create() {

--- a/frontend/src/app/game/scenes/EndScene.ts
+++ b/frontend/src/app/game/scenes/EndScene.ts
@@ -3,6 +3,7 @@ import {
     IResultData,
     Result
 } from '../elements/Result';
+import { GameRecoveryService } from '../services/recovery.service';
 import { BaseScene } from './BaseScene'
 import { IMenuInit } from './MenuScene';
 
@@ -13,7 +14,8 @@ export class    EndScene extends BaseScene {
     startTimeout: number | undefined;
 
     constructor(
-        sock: SocketIO.Socket, room: string
+        sock: SocketIO.Socket, room: string,
+        private readonly recoveryService: GameRecoveryService
     ) {
         super("End", sock, room);
         this.startTimeout = undefined;
@@ -21,25 +23,43 @@ export class    EndScene extends BaseScene {
 
     init(data: IResultData) {
         this.resultData = data;
-        this.socket.once("newGame", (data: IMenuInit) => {
-            window.clearTimeout(this.startTimeout);
-            this.startTimeout = undefined;
-            this.result?.destroy();
-            this.removeAllSocketListeners();
-            if (data.selection.heroA != undefined)
-                this.scene.start("MenuHero", data);
+        this.socket.once("newGame", (menuData: IMenuInit) => {
+            this.destroy();
+            if (menuData.selection.heroA != undefined)
+                this.scene.start("MenuHero", menuData);
             else
-                this.scene.start("Menu", data);
+                this.scene.start("Menu", menuData);
         });
         this.startTimeout = window.setTimeout(() => {
-            this.result?.destroy();
-            this.removeAllSocketListeners();
+            this.destroy();
             this.scene.start("Start");
         }, 15000);
+        this.recoveryService.setUp(this);
     }
 
     create() {
         if (this.resultData)
             this.result = new Result(this, this.resultData);
     }
+
+    destroy(): void {
+        if (this.startTimeout)
+        {
+            window.clearTimeout(this.startTimeout);
+            this.startTimeout = undefined;
+        }
+        this.result?.destroy();
+        this.removeAllListeners();
+    }
+
+    recover(data: IResultData): void {
+        /*
+        **  Generating new instance in case it recovers on a different
+        **  end scene.
+        */
+        this.destroy();
+        this.init(data);
+        this.create();
+    }
+
 }

--- a/frontend/src/app/game/scenes/MenuScene.ts
+++ b/frontend/src/app/game/scenes/MenuScene.ts
@@ -1,6 +1,7 @@
 import { Socket } from "socket.io-client";
 import { IMatchInitData } from "../elements/Match";
 import { MenuRenderer } from "../elements/MenuRenderer";
+import { GameRecoveryService } from "../services/recovery.service";
 import { BaseScene } from "./BaseScene";
 
 export interface   ISelectionData {
@@ -31,11 +32,10 @@ export class    MenuScene extends BaseScene {
 
     private _menuRenderer?: MenuRenderer;
 
-    constructor(sock: Socket, room: string, sceneName: string = "") {
-        if (sceneName != "")
-            super(sceneName, sock, room);
-        else
-            super("Menu", sock, room);
+    constructor(sock: Socket, room: string,
+                    readonly recoveryService: GameRecoveryService,
+                    sceneName: string = "Menu") {
+        super(sceneName, sock, room);
         this.role = "";
     }
 
@@ -43,9 +43,7 @@ export class    MenuScene extends BaseScene {
         this.role = initData.role;
         this.initData = initData.selection;
         this.socket.once("startMatch", (gameData: IMatchInitData) => {
-            if (this._menuRenderer)
-                this._menuRenderer.destroy();
-            this.removeAllSocketListeners();
+            this.destroy();
             if (this.role != "Spectator")
             {
                 this.scene.start("ClassicPlayer", {
@@ -62,11 +60,10 @@ export class    MenuScene extends BaseScene {
             }
         });
         this.socket.once("end", (data) => {
-            if (this._menuRenderer)
-                this._menuRenderer.destroy();
-            this.removeAllSocketListeners();
+            this.destroy();
             this.scene.start("End", data);
         });
+        this.recoveryService.setUp(this);
     }
 
     preload() {
@@ -86,6 +83,25 @@ export class    MenuScene extends BaseScene {
             this.initData,
             false
         );
+    }
+
+    destroy(): void {
+        this.removeAllListeners();
+        if (this._menuRenderer)
+            this._menuRenderer.destroy();
+    }
+
+    recover(data: IMenuInit): void {
+        if (this.role != data.role
+            || !this.initData
+            || this.initData.nickPlayerA != data.selection.nickPlayerA
+            || this.initData.nickPlayerB != data.selection.nickPlayerB)
+        {
+            this.destroy();
+            this.init(data);
+            this.preload();
+            this.create();
+        }
     }
 
 }

--- a/frontend/src/app/game/scenes/PlayerScene.ts
+++ b/frontend/src/app/game/scenes/PlayerScene.ts
@@ -2,6 +2,7 @@ import * as Phaser from 'phaser'
 import * as SocketIO from 'socket.io-client'
 import { LagCompensationService } from '../services/lag-compensation.service';
 import { LoadService } from '../services/load.service';
+import { GameRecoveryService } from '../services/recovery.service';
 import { SoundService } from '../services/sound.service';
 import { MatchScene } from './MatchScene';
 
@@ -14,10 +15,11 @@ export class    PlayerScene extends MatchScene {
         socket: SocketIO.Socket, room: string,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
-        override readonly soundService: SoundService
+        override readonly soundService: SoundService,
+        override readonly recoveryService: GameRecoveryService
     ) {
-        super("Player", socket, room, lagCompensator,
-                loadService, soundService);
+        super("Player", socket, room,
+                lagCompensator, loadService, soundService, recoveryService);
     }
 
     override create() {

--- a/frontend/src/app/game/scenes/SpectatorScene.ts
+++ b/frontend/src/app/game/scenes/SpectatorScene.ts
@@ -1,6 +1,7 @@
 import * as SocketIO from 'socket.io-client'
 import { LagCompensationService } from '../services/lag-compensation.service';
 import { LoadService } from '../services/load.service';
+import { GameRecoveryService } from '../services/recovery.service';
 import { SoundService } from '../services/sound.service';
 import { MatchScene } from './MatchScene';
 
@@ -10,10 +11,11 @@ export class    SpectatorScene extends MatchScene {
         sock: SocketIO.Socket, room: string,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
-        override readonly soundService: SoundService
+        override readonly soundService: SoundService,
+        override readonly recoveryService: GameRecoveryService
     ) {
-        super("Spectator", sock, room, lagCompensator,
-                loadService, soundService);
+        super("Spectator", sock, room,
+                lagCompensator, loadService, soundService, recoveryService);
     }
 
 }

--- a/frontend/src/app/game/services/recovery.service.ts
+++ b/frontend/src/app/game/services/recovery.service.ts
@@ -1,0 +1,96 @@
+import { Injectable } from "@angular/core";
+import { IMatchInitData } from "../elements/Match";
+import { IResultData } from "../elements/Result";
+import { BaseScene } from "../scenes/BaseScene";
+import { EndScene } from "../scenes/EndScene";
+import { MatchScene } from "../scenes/MatchScene";
+import { MenuHeroScene } from "../scenes/MenuHeroScene";
+import {
+    IMenuInit,
+    MenuScene
+} from "../scenes/MenuScene";
+import { StartScene } from "../scenes/StartScene";
+
+export type SceneId = "start"
+                        | "menuClassic"
+                        | "menuHero"
+                        | "match"
+                        | "end";
+
+export interface    IRecoverData {
+    readonly scene: SceneId;
+    readonly data: Readonly<IResultData | IMenuInit | IMatchInitData>
+}
+
+@Injectable({
+    providedIn: "root"
+})
+export class    GameRecoveryService {
+
+    constructor() {}
+
+    private _sceneTransition(scene: BaseScene, recData: IRecoverData): void {
+        let data: IResultData | IMenuInit | IMatchInitData;
+
+        if (recData.scene === "start")
+        {
+            scene.scene.start("Start");
+        }
+        else if (recData.scene === "end")
+        {
+            scene.scene.start("End", recData.data as IResultData);
+        }
+        else if (recData.scene === "menuClassic"
+                || recData.scene === "menuHero")
+        {
+            data = recData.data as IMenuInit;
+            if (data.hero)
+                scene.scene.start("MenuHero", data);
+            else
+                scene.scene.start("Menu", data);
+        }
+        else if (recData.scene === "match")
+        { // Improve!! There might be a case where role is not "Spectator"
+            data = recData.data as IMatchInitData;
+            scene.scene.start("Spectator", {
+                role: "Spectator",
+                matchData: data
+            });
+        }
+    }
+
+    setUp(scene: StartScene
+                    | EndScene | MenuScene
+                    | MenuHeroScene | MatchScene): void {
+        scene.setUpRecovery();
+        scene.socket.on("recoverData", (recData: IRecoverData) => {        
+            if (recData.scene === "start" && scene instanceof StartScene)
+            {
+                scene.recover(undefined);
+                return ;
+            }
+            else if (recData.scene === "end" && scene instanceof EndScene)
+            {
+                scene.recover(recData.data as IResultData);
+                return ;
+            }
+            else if (
+                (recData.scene === "menuHero" && scene instanceof MenuHeroScene)
+                    || (recData.scene === "menuClassic"
+                            && scene instanceof MenuScene)
+            )
+            {
+                scene.recover(recData.data as IMenuInit);
+                return ;
+            }
+            else if (recData.scene === "match" && scene instanceof MatchScene)
+            {
+                scene.recover(recData.data as IMatchInitData);
+                return ;
+            }
+            scene.destroy();
+            this._sceneTransition(scene, recData);
+        });
+    }
+
+}


### PR DESCRIPTION
Añadidos servicios de recuperación de estado del juego tanto en el servidor como en el cliente al cambiar de pestañas en el navegador.

De esta manera se evita que el jugador o espectador se quede atrapado en alguna escena del juego, o no refleje correctamente el estado actual del juego al volver a activar una pestaña previamente inactiva.

Closes #34 