### PR TITLE
Fix game results scene recovery

### DIFF
--- a/backend/src/game/game.updateService.ts
+++ b/backend/src/game/game.updateService.ts
@@ -79,7 +79,8 @@ export class    GameUpdateService {
     getGameClientStartData(roomId: string): IGameClientStart {
         const   game: Game = this.gameDataService.getGame(roomId);
     
-        if (game)
+        if (game
+                && game.state === GameState.Running)
             return (game.clientStartData());
         return (undefined);
     }


### PR DESCRIPTION
Arreglada vista errónea de escena resultados al cambiar de pestaña en el navegador y volver. Se volvía a mostrar la escena de la partida en lugar de la de resultados.

Closes #82 