### PR TITLE
Add timeout to game hero menu

### DIFF
--- a/backend/src/game/elements/GameSelection.ts
+++ b/backend/src/game/elements/GameSelection.ts
@@ -40,6 +40,7 @@ export interface    IGameSelectionData {
     heroAConfirmed?: boolean;
     heroBConfirmed?: boolean;
     stage?: StageId;
+    timeoutDate?: number;
     status: SelectionStatus;
 }
 
@@ -56,6 +57,8 @@ export class    GameSelection {
     private _heroAConfirmed?: boolean;
     private _heroBConfirmed?: boolean;
     private _stage?: number;
+    private _timeoutDate?: number;
+    private _timeout?: NodeJS.Timeout;
     private _status: SelectionStatus;
 
     constructor(initData: IGameSelectionInit, hero: boolean) {
@@ -72,6 +75,7 @@ export class    GameSelection {
             this._heroAConfirmed = false;
             this._heroBConfirmed = false;
             this._stage = StageId.Atlantis;
+            this._timeoutDate = Date.now() + 1.5 * 60 * 1000;
         }
         this._status = SelectionStatus.Hero;
     }
@@ -114,8 +118,26 @@ export class    GameSelection {
             heroAConfirmed: this._heroAConfirmed,
             heroBConfirmed: this._heroBConfirmed,
             stage: this._stage,
+            timeoutDate: this._timeoutDate,
             status: this._status
         });
+    }
+
+    get heroMenuTimeoutDate(): number | undefined {
+        return (this._timeoutDate);
+    }
+
+    set heroMenuTimeout(timeout: NodeJS.Timeout | undefined) {
+        if (!this._timeoutDate)
+            return ;
+        this._timeout = timeout;
+    }
+
+    clearHeroMenuTimeout(): void {
+        if (!this._timeout)
+            return ;
+        clearTimeout(this._timeout);
+        this._timeout = undefined;
     }
 
     private heroLeft(hero: HeroId): HeroId {
@@ -203,6 +225,14 @@ export class    GameSelection {
             if (player === "PlayerA")
                 this._status = SelectionStatus.Finished;
         }
+    }
+
+    forceConfirm(): void {
+        if (!this._timeoutDate)
+            return ;
+        this._heroAConfirmed = true;
+        this._heroBConfirmed = true;
+        this._status = SelectionStatus.Finished;
     }
 
 }

--- a/frontend/src/app/game/elements/MenuHeroRenderer.ts
+++ b/frontend/src/app/game/elements/MenuHeroRenderer.ts
@@ -9,6 +9,7 @@ import {
 import { MenuArrows } from "./MenuArrows";
 import { MenuRenderer } from "./MenuRenderer";
 import { SelectionStatus } from "./MenuSelector";
+import { Timer } from "./Timer";
 
 export class    MenuHeroRenderer extends MenuRenderer {
 
@@ -22,6 +23,7 @@ export class    MenuHeroRenderer extends MenuRenderer {
     private _sounds: SelectionSoundKeys;
     private _aArrows: MenuArrows;
     private _bArrows: MenuArrows;
+    private _timer: Timer;
 
     constructor(scene: MenuScene, initData: ISelectionData,
                     private readonly soundService: SoundService) {
@@ -55,6 +57,7 @@ export class    MenuHeroRenderer extends MenuRenderer {
             { x: 450, y: 220 },
             { x: 750, y: 220 }
         )).visible = false;
+        this._timer = new Timer(scene, 400, 50, initData.timeoutDate);
         (this._heroAImage = scene.add.image(
             200, 220,
             this.initImage(initData.heroA, this._heroImages,
@@ -190,6 +193,7 @@ export class    MenuHeroRenderer extends MenuRenderer {
         this._stageImage.destroy();
         this._aArrows.destroy();
         this._bArrows.destroy();
+        this._timer.destroy();
     }
 
 }

--- a/frontend/src/app/game/elements/Timer.ts
+++ b/frontend/src/app/game/elements/Timer.ts
@@ -1,0 +1,60 @@
+import { BaseScene } from "../scenes/BaseScene";
+import { Txt } from "./Txt";
+
+export class    Timer {
+
+    private _clockTxt: Txt;
+    private _clockIntervalId: number | undefined;
+    private _timeoutDate: number;
+
+    constructor(scene: BaseScene, xPos: number, yPos: number,
+                    timeoutDate: number) {
+        this._clockTxt = new Txt(scene, {
+            xPos: xPos,
+            yPos: yPos,
+            content: "--:--",
+            style: { fontSize: '20px', color: '#fff' },
+            xOrigin: 0.5,
+            yOrigin: 0.5,
+            depth: 1
+        });
+        this._timeoutDate = timeoutDate;
+        this._clockIntervalId = this._setClockInterval()
+    }
+
+    private _setClockInterval(): number {
+        return (
+            window.setInterval(() => {
+                let diff: number = this._timeoutDate - Date.now();
+                let min: number;
+                let sec: number;
+
+                if (diff <= 0)
+                {
+                    this._clockTxt.content = "00:00";
+                    window.clearInterval(this._clockIntervalId);
+                    return ;
+                }
+                min = (diff / 1000) / 60;
+                sec = (min - Math.floor(min)) * 60;
+                this._clockTxt.content =
+                    `${String(Math.floor(min)).padStart(2, '0')}`
+                    + ':'
+                    + `${String(Math.floor(sec)).padStart(2, '0')}`;
+            }, 1000)
+        );
+    }
+
+    private _clearClockInterval(): void {
+        if (!this._clockIntervalId)
+            return ;
+        window.clearInterval(this._clockIntervalId);
+        this._clockIntervalId = undefined;
+    }
+
+    destroy(): void {
+        this._clearClockInterval();
+        this._clockTxt.destroy();
+    }
+
+}

--- a/frontend/src/app/game/scenes/MenuScene.ts
+++ b/frontend/src/app/game/scenes/MenuScene.ts
@@ -16,6 +16,7 @@ export interface   ISelectionData {
     heroAConfirmed: boolean;
     heroBConfirmed: boolean;
     stage: number;
+    timeoutDate: number;
     status: number;
 }
 


### PR DESCRIPTION
Añadido timeout para el menú de selección de héroes, mostrando el tiempo restante en la parte superior de la ventana de juego para que los jugadores lo tengan en cuenta.

Si el tiempo se cumple y los jugadores todavía no han confirmado la selección de todos los elementos del juego, la partida empezará con los elementos que estén seleccionados en ese momento, hayan sido confirmados o no.