### PR TITLE
Game loop partition

### DIFF
--- a/backend/src/game/game.updateService.ts
+++ b/backend/src/game/game.updateService.ts
@@ -304,6 +304,7 @@ export class    GameUpdateService {
                 
                     for (const elem of runningGames)
                     {
+                        ++gamesPartition;
                         if (elem.game.state === GameState.Running)
                         {
                             this.gameUpdate(elem.game, elem.id);
@@ -315,7 +316,6 @@ export class    GameUpdateService {
                                 gamesPartition = 0;
                             }
                         }
-                        ++gamesPartition;
                     }
                 },
                 GameUpdateService.updateTimeInterval


### PR DESCRIPTION
Implementado particionado del loop de actualización de juegos para evitar bloquear el event loop de NodeJS durante períodos prolongados de tiempo. Al llegar al número máximo de juegos actualizados por partición, se invoca la función setImmediate para dar por finalizadas las actualizaciones de juegos durante la iteración actual del event loop de NodeJS y posponer las actualizaciones restantes, si las hubiera, para ejecutarlas en la siguiente iteración, liberando al servidor para despachar el resto de eventos pendientes del ciclo como requests, promesas, timers, peticiones a la base de datos, etc.

Lo ideal hubiera sido crear servicios independientes de actualización de snapshots para las distintas fases de actualización del juego, como procesado de inputs, reconciliación o cálculo de físicas, para después actualizar el estado de las instancias de juego desde fuera, en lugar de hacerlo internamente. De esa manera, se podrían gestionar esos cálculos mediante una cola de trabajos para despachar usando un pool de threads.