### PR TITLE
Fix friendship transaction

### DIFF
--- a/add-friendship.sh
+++ b/add-friendship.sh
@@ -1,0 +1,31 @@
+function updateToken {
+    AUTH_TOKEN=$(bash auth_token_generator.sh)
+}
+
+function getAuthHeader {
+    echo "Authorization: Bearer $AUTH_TOKEN"
+}
+
+HOST=http://localhost:3000
+ENDPOINT=users/me/friends
+
+if [[ ! (-n $1) || ! ($1 -eq $1) ]]
+then
+    echo "Pass the id of the user that will receive the invite."
+    exit 1
+fi
+
+updateToken
+HTTP_STATUS_CODE=$(curl $HOST/$ENDPOINT -s \
+                        -w "%{response_code}" \
+                        -o /dev/null \
+                        -H "$(getAuthHeader)" \
+                        -H "Content-Type: application/json" \
+                        -d '{
+                                "receiverId":'$1'
+                            }')
+if [[ $HTTP_STATUS_CODE -ge 400 ]]
+    then
+        echo Request failed with status code: $HTTP_STATUS_CODE
+        exit 1
+    fi

--- a/backend/src/user/services/friendship.service.ts
+++ b/backend/src/user/services/friendship.service.ts
@@ -2,8 +2,8 @@ import {
     Injectable,
     HttpException,
     HttpStatus,
-    NotAcceptableException,
-    NotFoundException
+    NotFoundException,
+    BadRequestException
 } from "@nestjs/common";
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from 'src/user/entities/user.entity';
@@ -62,12 +62,18 @@ export class FriendshipService {
             friendship.senderId = friendship.sender.id;
             friendship.receiverId = friendship.receiver.id;
             if ((await queryRunner.manager.find(FriendshipEntity, {
-                where: {
-                    senderId: receiverId,
-                    receiverId: senderId
-                }
+                where: [
+                    {
+                        senderId: receiverId,
+                        receiverId: senderId
+                    },
+                    {
+                        senderId: senderId,
+                        receiverId: receiverId
+                    }
+                ]
             })).length != 0)
-                throw new NotAcceptableException("Friendship exists already");
+                throw new BadRequestException("Friendship exists already");
             await queryRunner.manager.insert(FriendshipEntity, friendship);
             await queryRunner.commitTransaction();
         } catch (err) {


### PR DESCRIPTION
Añadido el rollback de la transacción en el catch para que se cancelen las operaciones realizadas si algo falla. Y se ha quitado el throw del catch para permitir que se ejecute el contenido del bloque "finally" en cualquier caso, ya que éste contiene el cierre de la transacción.