### PR TITLE
Fix game room switch

### DIFF
--- a/frontend/src/app/game/elements/Match.ts
+++ b/frontend/src/app/game/elements/Match.ts
@@ -47,6 +47,7 @@ export class    Match {
     private _when: number;
 
     constructor(scene: MatchScene, initData: IMatchInitData,
+                    showInitCount: boolean,
                     private readonly soundService?: SoundService) {
         this._playerA = new Player(scene, initData.playerA, soundService);
         this._playerB = new Player(scene, initData.playerB, soundService);
@@ -74,7 +75,11 @@ export class    Match {
         });
         this._when = initData.when;
         this._pointTitle = new PointTitle(scene);
-        this._pointTitle.display();
+        if (this._ball.data.xVel === 0
+                && this._playerA.score === 0
+                && this._playerB.score === 0
+                && showInitCount)
+            this._pointTitle.display();
     }
 
     // Returns a Deep Copy of IPlayerData

--- a/frontend/src/app/game/elements/PointTitle.ts
+++ b/frontend/src/app/game/elements/PointTitle.ts
@@ -9,7 +9,7 @@ export class    PointTitle {
     private _scene: MatchScene;
 
     constructor(scene: MatchScene) {
-        this._title = new Txt(scene, {
+        (this._title = new Txt(scene, {
             xPos: Number(scene.game.config.width) / 2,
             yPos: Number(scene.game.config.height) / 2,
             content: '3',
@@ -23,7 +23,7 @@ export class    PointTitle {
             xOrigin: 0.5,
             yOrigin: 0.5,
             depth: 0
-        });
+        })).visible = false;
         this._tween = undefined;
         this._scene = scene;
     }
@@ -35,6 +35,7 @@ export class    PointTitle {
             this._tween.restart();
             return ;
         }
+        this._title.visible = true;
         this._tween = this._scene.tweens.add({
             targets: this._title.element,
             scale: 0.1,

--- a/frontend/src/app/game/scenes/BaseScene.ts
+++ b/frontend/src/app/game/scenes/BaseScene.ts
@@ -8,19 +8,17 @@ import { IMenuInit } from './MenuScene';
 export abstract class    BaseScene extends Phaser.Scene {
 
     socket: SocketIO.Socket;
-    room: string;
     initTxt?: Txt;
 
     constructor(
-        role: string, socket: SocketIO.Socket, room: string
+        role: string, socket: SocketIO.Socket
     ) {
         super(role);
 
         this.socket = socket;
-        this.room = room;
     }
 
-    private removeAllSocketListeners(): void {
+    removeAllListeners(): void {
         this.socket.off("leftSelection");
         this.socket.off("rightSelection");
         this.socket.off("confirmSelection");
@@ -29,25 +27,6 @@ export abstract class    BaseScene extends Phaser.Scene {
         this.socket.off("end");
         this.socket.off("matchUpdate");
         this.socket.off("recoverData");
-    }
-
-    private removeAllGameListeners(): void {
-        this.game.events.off("focus");
-    }
-
-    removeAllListeners(): void {
-        this.removeAllSocketListeners();
-        this.removeAllGameListeners();
-    }
-
-    private emitRecover(): void {
-        this.socket.emit("recover", this.room);
-    }
-
-    setUpRecovery(): void {
-        this.game.events.on("focus", () => {
-            this.emitRecover();
-        });
     }
 
     abstract destroy(): void;

--- a/frontend/src/app/game/scenes/ClassicPlayerScene.ts
+++ b/frontend/src/app/game/scenes/ClassicPlayerScene.ts
@@ -11,13 +11,13 @@ export class    ClassicPlayerScene extends MatchScene {
     cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
 
     constructor(
-        socket: SocketIO.Socket, room: string,
+        socket: SocketIO.Socket,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
         override readonly soundService: SoundService,
         override readonly recoveryService: GameRecoveryService
     ) {
-        super("ClassicPlayer", socket, room,
+        super("ClassicPlayer", socket,
                 lagCompensator, loadService, soundService, recoveryService);
     }
 

--- a/frontend/src/app/game/scenes/EndScene.ts
+++ b/frontend/src/app/game/scenes/EndScene.ts
@@ -14,10 +14,10 @@ export class    EndScene extends BaseScene {
     startTimeout: number | undefined;
 
     constructor(
-        sock: SocketIO.Socket, room: string,
+        sock: SocketIO.Socket,
         private readonly recoveryService: GameRecoveryService
     ) {
-        super("End", sock, room);
+        super("End", sock);
         this.startTimeout = undefined;
     }
 

--- a/frontend/src/app/game/scenes/MenuHeroScene.ts
+++ b/frontend/src/app/game/scenes/MenuHeroScene.ts
@@ -21,15 +21,22 @@ export class    MenuHeroScene extends MenuScene {
     cursors?: Phaser.Types.Input.Keyboard.CursorKeys;
     enter?: any; //Enter key
 
-    constructor(sock: Socket, room: string,
+    constructor(sock: Socket,
                     private readonly soundService: SoundService,
                     override readonly recoveryService: GameRecoveryService) {
-        super(sock, room, recoveryService, "MenuHero");
+        super(sock, recoveryService, "MenuHero");
     }
 
+    /*
+    **  If this.initData is not undefined means service recovery assigned
+    **  an updated value to this.initData first, and must not be reassigned.
+    */
     override init(initData: IMenuInit) {
-        this.role = initData.role;
-        this.initData = initData.selection;
+        if (!this.initData)
+        {
+            this.role = initData.role;
+            this.initData = initData.selection;
+        }
         this.socket.once("startMatch", (gameData: IMatchInitData) => {
             this.destroy();
             if (this.role != "Spectator")
@@ -134,18 +141,24 @@ export class    MenuHeroScene extends MenuScene {
     override destroy(): void {
         super.destroy();
         if (this._menuHeroRenderer)
+        {
             this._menuHeroRenderer.destroy();
+            delete this._menuHeroRenderer;
+        }
         this.soundService.destroy();
+        this.initData = undefined;
     }
 
     override recover(data: IMenuInit): void {
+        this.role = data.role;
+        this.initData = data.selection;
         /*
         **  This can be improved checking if it is necessary
         **  to reset the scene, update some values, or do nothing.
         */
-       this._menuHeroRenderer?.destroy();
-       this.role = data.role;
-       this.initData = data.selection;
+        if (!this._menuHeroRenderer)
+            return ;
+        this._menuHeroRenderer.destroy();
         this._menuHeroRenderer = new MenuHeroRenderer(
             this,
             this.initData,

--- a/frontend/src/app/game/scenes/MenuScene.ts
+++ b/frontend/src/app/game/scenes/MenuScene.ts
@@ -33,10 +33,10 @@ export class    MenuScene extends BaseScene {
 
     private _menuRenderer?: MenuRenderer;
 
-    constructor(sock: Socket, room: string,
+    constructor(sock: Socket,
                     readonly recoveryService: GameRecoveryService,
                     sceneName: string = "Menu") {
-        super(sceneName, sock, room);
+        super(sceneName, sock);
         this.role = "";
     }
 
@@ -90,6 +90,7 @@ export class    MenuScene extends BaseScene {
         this.removeAllListeners();
         if (this._menuRenderer)
             this._menuRenderer.destroy();
+        this.initData = undefined;
     }
 
     recover(data: IMenuInit): void {

--- a/frontend/src/app/game/scenes/PlayerScene.ts
+++ b/frontend/src/app/game/scenes/PlayerScene.ts
@@ -12,13 +12,13 @@ export class    PlayerScene extends MatchScene {
     powerKeys: any;
 
     constructor(
-        socket: SocketIO.Socket, room: string,
+        socket: SocketIO.Socket,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
         override readonly soundService: SoundService,
         override readonly recoveryService: GameRecoveryService
     ) {
-        super("Player", socket, room,
+        super("Player", socket,
                 lagCompensator, loadService, soundService, recoveryService);
     }
 

--- a/frontend/src/app/game/scenes/SpectatorScene.ts
+++ b/frontend/src/app/game/scenes/SpectatorScene.ts
@@ -8,13 +8,13 @@ import { MatchScene } from './MatchScene';
 export class    SpectatorScene extends MatchScene {
 
     constructor(
-        sock: SocketIO.Socket, room: string,
+        sock: SocketIO.Socket,
         override readonly lagCompensator: LagCompensationService,
         override readonly loadService: LoadService,
         override readonly soundService: SoundService,
         override readonly recoveryService: GameRecoveryService
     ) {
-        super("Spectator", sock, room,
+        super("Spectator", sock,
                 lagCompensator, loadService, soundService, recoveryService);
     }
 

--- a/frontend/src/app/game/scenes/StartScene.ts
+++ b/frontend/src/app/game/scenes/StartScene.ts
@@ -11,10 +11,10 @@ export class    StartScene extends BaseScene {
     startTitles?: StartTitles;
 
     constructor(
-        sock: SocketIO.Socket, room: string,
+        sock: SocketIO.Socket,
         private readonly recoveryService: GameRecoveryService
     ) {
-        super("Start", sock, room);
+        super("Start", sock);
     }
 
     init() {

--- a/frontend/src/app/game/services/recovery.service.ts
+++ b/frontend/src/app/game/services/recovery.service.ts
@@ -3,7 +3,10 @@ import { IMatchInitData } from "../elements/Match";
 import { IResultData } from "../elements/Result";
 import { BaseScene } from "../scenes/BaseScene";
 import { EndScene } from "../scenes/EndScene";
-import { MatchScene } from "../scenes/MatchScene";
+import {
+    IMatchSceneInit,
+    MatchScene
+} from "../scenes/MatchScene";
 import { MenuHeroScene } from "../scenes/MenuHeroScene";
 import {
     IMenuInit,
@@ -61,8 +64,9 @@ export class    GameRecoveryService {
             {
                 scene.scene.start("Spectator", {
                     role: data.role,
-                    matchData: data.gameData
-                });
+                    matchData: data.gameData,
+                    recover: true
+                } as IMatchSceneInit);
             }
             else
             {
@@ -70,15 +74,17 @@ export class    GameRecoveryService {
                 {
                     scene.scene.start("Player", {
                         role: data.role,
-                        matchData: data.gameData
-                    });
+                        matchData: data.gameData,
+                        recover: true
+                    } as IMatchSceneInit);
                 }
                 else
                 {
                     scene.scene.start("ClassicPlayer", {
                         role: data.role,
-                        matchData: data.gameData
-                    });
+                        matchData: data.gameData,
+                        recover: true
+                    } as IMatchSceneInit);
                 }
             }
         }
@@ -87,8 +93,7 @@ export class    GameRecoveryService {
     setUp(scene: StartScene
                     | EndScene | MenuScene
                     | MenuHeroScene | MatchScene): void {
-        scene.setUpRecovery();
-        scene.socket.on("recoverData", (recData: IRecoverData) => {        
+        scene.socket.on("recoverData", (recData: IRecoverData) => {
             if (recData.scene === "start" && scene instanceof StartScene)
             {
                 scene.recover(undefined);


### PR DESCRIPTION
Gestionado cambio de sala en el componente del juego del frontend cuando el cambio de sala se realiza sin reinstanciar el componente.

También se ha mejorado la detección de visibilidad del juego al cambiar de escena manteniendo activo el evento de detección de visibilidad del juego durante todo el ciclo de vida de la instancia de juego, en lugar de activarlo y desactivarlo en cada cambio de escena del juego. Estos cambios se han añadido a esta pull request porque se han visto afectados por las modificaciones en la gestión del cambio de sala.

Closes #96 