### PR TITLE
Fix infinite message retries on WS exception

### DIFF
--- a/frontend/src/app/game/services/socket.service.ts
+++ b/frontend/src/app/game/services/socket.service.ts
@@ -25,6 +25,7 @@ export class    SocketService {
     private _connectAttempts: number;
     private _authAttempts: number;
     private _authenticating: boolean;
+    private _lastAuthSuccess: number;
     private _failedEvents: SocketExceptionData[];
 
     constructor(
@@ -37,6 +38,7 @@ export class    SocketService {
         this._connectAttempts = 0;
         this._authAttempts = 0;
         this._authenticating = false;
+        this._lastAuthSuccess = 0;
         this._failedEvents = [];
     }
 
@@ -98,9 +100,15 @@ export class    SocketService {
             }
         });
         this._socket.on("authSuccess", () => {
+            const   currentTime: number = Date.now();
+        
             this._authenticating = false;
             this._authAttempts = 0;
-            this._emitFailedEvents();
+            if (currentTime - this._lastAuthSuccess > 5000)
+                this._emitFailedEvents();
+            else
+                this._failedEvents = [];
+            this._lastAuthSuccess = currentTime;
         });
         this._socket.on("disconnect", () => {
             this._reconnect();


### PR DESCRIPTION
Limitado el número de reintentos de envío de mensajes fallidos para la conexión de websockets cuando la excepción no se corresponde con Forbidden.

Closes #141 