### PR TITLE
Fix unqueue on room rejoin

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -94,6 +94,7 @@ export class    GameGateway implements OnGatewayInit,
         @MessageBody() roomId: number
     ) {
         const   roomName: string = SocketHelper.roomIdToName(roomId);
+        const   username: string = client.data.username;
         const   [initScene, initData]: [string,
                                         IMenuInit |
                                         IGameClientStart |
@@ -102,18 +103,22 @@ export class    GameGateway implements OnGatewayInit,
                     this.updateService.getClientInitData(roomName);
     
         this.roomService.join(
-            client.data.username,
+            username,
             roomName
         );
-        this.matchMakingService.emitAllQueuesLength(roomName, client.id);
+        await this.matchMakingService.emitQueuesInfo(
+            roomName,
+            client.id,
+            username
+        );
         if (initScene && initData)
             client.emit(initScene, initData);
         await this.matchMakingService.updateNextPlayerRoom(
-            client.data.username,
+            username,
             roomName,
             true
         );
-        console.log(`${client.data.username} joined Game room ${roomName}`);
+        console.log(`${username} joined Game room ${roomName}`);
     }
 
     @UseGuards(GameAuthGuard, GameRoomGuard)

--- a/backend/src/game/game.matchmaking.service.ts
+++ b/backend/src/game/game.matchmaking.service.ts
@@ -86,6 +86,15 @@ export class    GameMatchmakingService {
         );
     }
 
+    async emitQueuesInfo(gameId: string, emitTo: string,
+                            username: string): Promise<void> {
+        let userQueueUpdate: UserQueueUpdate;
+    
+        this.emitAllQueuesLength(gameId, emitTo);
+        userQueueUpdate = await this.queueService.findUser(username);
+        this._emitUserQueueUpdate(username, userQueueUpdate);
+    }
+
     isNextPlayer(username: string, roomId: string): boolean {
         const   nextPlayers: NextPlayerPair | undefined =
                             this.queueService.getNextPlayers(roomId);
@@ -165,7 +174,8 @@ export class    GameMatchmakingService {
     }
 
     async removeFromAllQueues(username: string): Promise<void> {
-        const   gameId: string = await this.queueService.findUser(username);
+        const   gameId: string =
+                    (await this.queueService.findUser(username)).roomId || "";
         let     lengthUpdate: [number, GameType] | undefined;
     
         if (!gameId)
@@ -408,14 +418,15 @@ export class    GameMatchmakingService {
 
     // Called when a player joins or leaves a game room.
     async updateNextPlayerRoom(username: string, gameId: string,
-                            join: boolean): Promise<void> {
+                                join: boolean): Promise<void> {
         const   nextPlayers: NextPlayerPair | undefined =
                             this.queueService.updateNextPlayerRoom(
                                                 username,
                                                 gameId,
                                                 join);
-        const   registeredRoom: string = await this.queueService.findUser(
-                                                                    username);
+        const   registeredRoom: string =
+                            (await this.queueService.findUser(username)).roomId
+                            || "";
 
         if (registeredRoom != gameId && join)
             await this.updateNextPlayerRoom(username, registeredRoom, false);


### PR DESCRIPTION
Añadida la posibilidad de que el cliente pueda desinscribirse de una cola de juego después de salir de la sala donde se inscribió y volver.

No se estaba enviando la información de suscripción a las colas de juego del usuario cada vez que entraba a la sala. Sólo se estaba enviando el número de usuarios suscritos a cada cola de la sala. Así que al final era problema del servidor.

Closes #147 