### PR TITLE
Fix role check for left/right menu player input

### DIFF
--- a/frontend/src/app/game/elements/MenuSelector.ts
+++ b/frontend/src/app/game/elements/MenuSelector.ts
@@ -169,7 +169,7 @@ export class    MenuSelector {
         }
     }
 
-    serverUpdate(data: ISelectionData, role?: string): void {
+    serverUpdate(data: ISelectionData, role: string): void {
         if (this._status === SelectionStatus.Hero)
         {
             this.updateHeroes(data);

--- a/frontend/src/app/game/scenes/MenuHeroScene.ts
+++ b/frontend/src/app/game/scenes/MenuHeroScene.ts
@@ -96,10 +96,10 @@ export class    MenuHeroScene extends MenuScene {
         );
         this.selector = new MenuSelector(this.initData, this._menuHeroRenderer);
         this.socket.on("leftSelection", (data: ISelectionData) => {
-            this.selector?.serverUpdate(data);
+            this.selector?.serverUpdate(data, this.role);
         });
         this.socket.on("rightSelection", (data: ISelectionData) => {
-            this.selector?.serverUpdate(data);
+            this.selector?.serverUpdate(data, this.role);
         });
         this.socket.on("confirmSelection", (data: ISelectionData) => {
             this.selector?.serverUpdate(data, this.role);


### PR DESCRIPTION
Solucionado fallo en chequeo de rol de jugador al recibir input del otro jugador en la selección de escenario en el modo de juego héroe. Esto causaba que cuando el jugador B, que no puede elegir escenario, mandaba input de selección al servidor, el cliente del jugador A mostraba el escenario como ya confirmado al recibir ese input.