### PR TITLE
Restrict hero invocation to once per point

### DIFF
--- a/backend/src/game/elements/Game.ts
+++ b/backend/src/game/elements/Game.ts
@@ -286,6 +286,11 @@ export class   Game {
         {
             this._playerA.updateHero(secondsElapsed);
             this._playerB.updateHero(secondsElapsed);
+            if (this._pointTransition)
+            {
+                this._playerA.hero.resetInvocation();
+                this._playerB.hero.resetInvocation();
+            }
         }
     }
 

--- a/backend/src/game/elements/Hero.ts
+++ b/backend/src/game/elements/Hero.ts
@@ -108,6 +108,10 @@ export class    Hero {
         this._activeSprite = up ? 2 : 1;
     }
 
+    resetInvocation(): void {
+        this._pointInvocation = false;
+    }
+
     private getActiveSprite(): ISprite {
         if (!this._activeSprite)
             return (undefined);
@@ -237,7 +241,6 @@ export class    Hero {
         sprite.xPos = sprite.xPosInit;
         sprite.yPos = sprite.yPosInit;
         this._activeSprite = 0;
-        this._pointInvocation = false; // For testing
     }
 
     private checkEnd(sprite: ISprite): void {    

--- a/frontend/src/app/game/services/lag-compensation.service.ts
+++ b/frontend/src/app/game/services/lag-compensation.service.ts
@@ -154,7 +154,7 @@ export class    LagCompensationService {
                 || playerData.hero.active)
             return ;
         playerData.hero.active = move;
-        playerData.hero.pointInvocation = false; //Leaving it false for testing
+        playerData.hero.pointInvocation = true;
     }
 
     input(buffer: IMatchData[], paddleMove: number, heroMove: number,


### PR DESCRIPTION
En el modo héroe del juego, los jugadores pueden invocar a su héroe una vez por punto.