### PR TITLE
Fix game queue info

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -114,15 +114,10 @@ export class    GameGateway implements OnGatewayInit,
                 undefined] =
             this.updateService.getClientInitData(roomName, client);
 
-        this.roomService.join(
+        await this.roomService.join(
             client,
             username,
             roomName
-        );
-        await this.matchMakingService.emitQueuesInfo(
-            roomName,
-            client.id,
-            username
         );
         if (initScene && initData)
             client.emit(initScene, initData);
@@ -146,7 +141,7 @@ export class    GameGateway implements OnGatewayInit,
         @MessageBody() roomId: number
     ) {
         const roomName: string = SocketHelper.roomIdToName(roomId);
-        this.roomService.leave(
+        await this.roomService.leave(
             client,
             client.data.username,
             roomName
@@ -158,6 +153,20 @@ export class    GameGateway implements OnGatewayInit,
         );
         console.log(`${client.data.username} left Game room ${roomName}`);
         /* emit event to room actualize event */
+    }
+
+    @UseGuards(GameAuthGuard, GameRoomGuard)
+    @UsePipes(StringValidator)
+    @SubscribeMessage('getQueueInfo')
+    async getQueueInfo(
+        @ConnectedSocket() client: Socket,
+        @MessageBody() roomId: string
+    ) {
+        await this.matchMakingService.emitQueuesInfo(
+            roomId,
+            client.id,
+            client.data.username
+        );
     }
 
     @UseGuards(GameAuthGuard, GameRoomGuard)

--- a/frontend/src/app/game/game-queue/game-queue.component.ts
+++ b/frontend/src/app/game/game-queue/game-queue.component.ts
@@ -9,6 +9,7 @@ import {
     Subscription
 } from 'rxjs';
 import { QueueService } from '../services/queue.service';
+import { SocketService } from '../services/socket.service';
 
 export type QueueType = "classic" | "hero";
 
@@ -37,7 +38,8 @@ export class GameQueueComponent implements OnInit, OnDestroy {
     @Input('roomId') roomId: string = '';
 
     constructor(
-        private readonly queueService: QueueService
+        private readonly queueService: QueueService,
+        private readonly socketService: SocketService
     ) {
         this.classicLength = 0;
         this.heroLength = 0;
@@ -103,6 +105,7 @@ export class GameQueueComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         this._subscribe();
+        this.socketService.emit("getQueueInfo", this.roomId);
     }
 
     addToQueue() {


### PR DESCRIPTION
Solucionado problema al recibir información de colas de juego en el cliente.

Lo que se ha hecho es crear un nuevo event handler en el gateway del servidor al que el cliente emitirá un evento indicando que quiere recibir información de las colas de juego de una sala concreta. El cliente emitirá este evento al entrar a una sala, pero después de haberse suscrito al evento correspondiente de recepción de la información.