### PR TITLE
Fix spectator stage confirm

### DIFF
--- a/srcs/frontend/src/app/game/elements/MenuSelector.ts
+++ b/srcs/frontend/src/app/game/elements/MenuSelector.ts
@@ -186,7 +186,7 @@ export class    MenuSelector {
                 this._stage = data.stage;
                 this._renderer.render(this._status, "PlayerA", this._stage, false);
             }
-            else if (role != "PlayerA")
+            else if (role != "PlayerA" && this._status != data.status)
                 this._renderer.finish(this._stage);
         }
     }


### PR DESCRIPTION
Solucionado fallo en la vista del menú de selección de escenario para los espectadores.

Cuando el jugador B mandaba un input cualquiera al servidor, y no se producía ningún cambio en la selección de escenario, porque el único que puede elegir es el jugador A. Los espectadores lo interpretaban como una confirmación de escenario y mostraban la imagen del escenario como confirmada.