### PR TITLE
Fix running game instances removal

### DIFF
--- a/srcs/backend/src/game/game.data.service.ts
+++ b/srcs/backend/src/game/game.data.service.ts
@@ -110,7 +110,7 @@ export class    GameDataService {
         let     index: number;
     
         index = this._runningGames.findIndex((elem: RunningGame) => {
-            elem.id === gameId
+            return (elem.id === gameId);
         });
         if (index != -1)
             this._runningGames.splice(index, 1);


### PR DESCRIPTION
Solucionado error al buscar el índice del id de juego que se almacena en el array de instancias de juego en curso.